### PR TITLE
Status handler infrastructure and API impl

### DIFF
--- a/app/env.js
+++ b/app/env.js
@@ -28,6 +28,7 @@ const vars = envalid.cleanEnv(process.env, {
   API_VERSION: envalid.str({ default: version }),
   API_MAJOR_VERSION: envalid.str({ default: 'v3' }),
   FILE_UPLOAD_MAX_SIZE: envalid.num({ default: 200 * 1024 * 1024 }),
+  SUBSTRATE_STATUS_POLL_PERIOD_MS: envalid.num({ default: 30 * 1000 }),
 })
 
 module.exports = {

--- a/app/env.js
+++ b/app/env.js
@@ -29,6 +29,7 @@ const vars = envalid.cleanEnv(process.env, {
   API_MAJOR_VERSION: envalid.str({ default: 'v3' }),
   FILE_UPLOAD_MAX_SIZE: envalid.num({ default: 200 * 1024 * 1024 }),
   SUBSTRATE_STATUS_POLL_PERIOD_MS: envalid.num({ default: 30 * 1000 }),
+  SUBSTRATE_STATUS_TIMEOUT_MS: envalid.num({ default: 2 * 1000 }),
 })
 
 module.exports = {

--- a/app/serviceStatus/apiStatus.js
+++ b/app/serviceStatus/apiStatus.js
@@ -1,11 +1,24 @@
 const { startStatusHandler, serviceState } = require('../util/statusPoll')
-// const { substrateApi } = require('../util/substrateApi')
+const { substrateApi } = require('../util/substrateApi')
 const { SUBSTRATE_STATUS_POLL_PERIOD_MS, SUBSTRATE_STATUS_TIMEOUT_MS } = require('../env')
 
-const getStatus = () => {
+const getStatus = async () => {
+  await substrateApi.isReady
+  const [chain, runtime] = await Promise.all([substrateApi.runtimeChain, substrateApi.runtimeVersion])
   return {
     status: serviceState.UP,
-    detail: {},
+    detail: {
+      chain,
+      runtime: {
+        name: runtime.specName,
+        versions: {
+          spec: runtime.specVersion.toNumber(),
+          impl: runtime.implVersion.toNumber(),
+          authoring: runtime.authoringVersion.toNumber(),
+          transaction: runtime.transactionVersion.toNumber(),
+        },
+      },
+    },
   }
 }
 

--- a/app/serviceStatus/apiStatus.js
+++ b/app/serviceStatus/apiStatus.js
@@ -1,6 +1,6 @@
 const { startStatusHandler, serviceState } = require('../util/statusPoll')
 // const { substrateApi } = require('../util/substrateApi')
-const { SUBSTRATE_STATUS_POLL_PERIOD_MS } = require('../env')
+const { SUBSTRATE_STATUS_POLL_PERIOD_MS, SUBSTRATE_STATUS_TIMEOUT_MS } = require('../env')
 
 const getStatus = () => {
   return {
@@ -9,6 +9,11 @@ const getStatus = () => {
   }
 }
 
-const startApiStatus = () => startStatusHandler({ getStatus, pollingPeriodMs: SUBSTRATE_STATUS_POLL_PERIOD_MS })
+const startApiStatus = () =>
+  startStatusHandler({
+    getStatus,
+    pollingPeriodMs: SUBSTRATE_STATUS_POLL_PERIOD_MS,
+    serviceTimeoutMs: SUBSTRATE_STATUS_TIMEOUT_MS,
+  })
 
 module.exports = startApiStatus

--- a/app/serviceStatus/apiStatus.js
+++ b/app/serviceStatus/apiStatus.js
@@ -1,0 +1,14 @@
+const { startStatusHandler, serviceState } = require('../util/statusPoll')
+// const { substrateApi } = require('../util/substrateApi')
+const { SUBSTRATE_STATUS_POLL_PERIOD_MS } = require('../env')
+
+const getStatus = () => {
+  return {
+    status: serviceState.UP,
+    detail: {},
+  }
+}
+
+const startApiStatus = () => startStatusHandler({ getStatus, pollingPeriodMs: SUBSTRATE_STATUS_POLL_PERIOD_MS })
+
+module.exports = startApiStatus

--- a/app/serviceStatus/index.js
+++ b/app/serviceStatus/index.js
@@ -1,0 +1,13 @@
+const startApiStatus = require('./apiStatus')
+const { buildCombinedHandler } = require('../util/statusPoll')
+
+const startStatusHandlers = async () => {
+  const handlers = new Map()
+  handlers.set('api', await startApiStatus())
+
+  return buildCombinedHandler(handlers)
+}
+
+module.exports = {
+  startStatusHandlers,
+}

--- a/app/util/statusPoll.js
+++ b/app/util/statusPoll.js
@@ -1,0 +1,95 @@
+const serviceState = {
+  UP: Symbol('status-up'),
+  DOWN: Symbol('status-down'),
+  ERROR: Symbol('status-error'),
+}
+const UNKNOWN = Symbol('status-unknown')
+const stateSymbols = new Set(Object.values(serviceState))
+
+const startStatusHandler = async ({ pollingPeriodMs, getStatus }) => {
+  const status = {
+    status: UNKNOWN,
+    detail: null,
+  }
+  let timeoutHandle = null,
+    stop = false
+
+  const resetStatus = () => {
+    status.status = serviceState.ERROR
+    status.detail = null
+  }
+
+  const updateStatus = async () => {
+    try {
+      const newStatus = await getStatus()
+
+      if (stateSymbols.has(newStatus.status)) {
+        status.status = newStatus.status
+        status.detail = newStatus.detail === undefined ? null : newStatus.detail
+      } else {
+        resetStatus()
+      }
+    } catch (err) {
+      resetStatus()
+    }
+  }
+
+  const statusLoop = async () => {
+    await updateStatus()
+    if (!stop) {
+      timeoutHandle = setTimeout(statusLoop, pollingPeriodMs)
+    }
+  }
+
+  statusLoop()
+
+  return {
+    get status() {
+      return status.status
+    },
+    get detail() {
+      return status.detail
+    },
+    close: () => {
+      stop = true
+      clearTimeout(timeoutHandle)
+    },
+  }
+}
+
+const buildCombinedHandler = async (handlerMap) => {
+  const getStatus = () =>
+    [...handlerMap].reduce((acc, [, h]) => {
+      const status = h.status
+      if (acc === serviceState.UP) {
+        return status
+      }
+      if (acc === serviceState.DOWN) {
+        return acc
+      }
+      if (status === serviceState.DOWN) {
+        return status
+      }
+      return acc
+    }, serviceState.UP)
+
+  return {
+    get status() {
+      return getStatus()
+    },
+    get detail() {
+      return Object.fromEntries([...handlerMap].map(([name, { detail }]) => [name, detail]))
+    },
+    close: () => {
+      for (const { handler } of handlerMap.values) {
+        handler.close()
+      }
+    },
+  }
+}
+
+module.exports = {
+  serviceState,
+  startStatusHandler,
+  buildCombinedHandler,
+}

--- a/app/util/statusPoll.js
+++ b/app/util/statusPoll.js
@@ -62,18 +62,18 @@ const startStatusHandler = async ({ pollingPeriodMs, serviceTimeoutMs, getStatus
 
 const buildCombinedHandler = async (handlerMap) => {
   const getStatus = () =>
-    [...handlerMap].reduce((acc, [, h]) => {
-      const status = h.status
-      if (acc === serviceState.UP) {
-        return status
+    [...handlerMap].reduce((accStatus, [, h]) => {
+      const handlerStatus = h.status
+      if (accStatus === serviceState.UP) {
+        return handlerStatus
       }
-      if (acc === serviceState.DOWN) {
-        return acc
+      if (accStatus === serviceState.DOWN) {
+        return accStatus
       }
-      if (status === serviceState.DOWN) {
-        return status
+      if (handlerStatus === serviceState.DOWN) {
+        return handlerStatus
       }
-      return acc
+      return accStatus
     }, serviceState.UP)
 
   return {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
       - 8080:8080
       - 5001:5001
   dscp-node:
-    image: ghcr.io/digicatapult/dscp-node:v3.0.0
+    image: ghcr.io/digicatapult/dscp-node:latest
     command:
       --base-path /data/
       --dev

--- a/helm/dscp-api/Chart.yaml
+++ b/helm/dscp-api/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: dscp-api
-appVersion: '4.0.1'
+appVersion: '4.0.2'
 description: A Helm chart for dscp-api
-version: '4.0.1'
+version: '4.0.2'
 type: application
 dependencies:
   - name: dscp-node

--- a/helm/dscp-api/values.yaml
+++ b/helm/dscp-api/values.yaml
@@ -24,7 +24,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/digicatapult/dscp-api
   pullPolicy: IfNotPresent
-  tag: 'v4.0.1'
+  tag: 'v4.0.2'
 
 dscpNode:
   enabled: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dscp-api",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dscp-api",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "ISC",
       "dependencies": {
         "@polkadot/api": "^5.9.1",
@@ -42,6 +42,7 @@
         "nyc": "^15.1.0",
         "pino-colada": "^2.1.0",
         "prettier": "^2.3.1",
+        "sinon": "^13.0.1",
         "supertest": "^6.1.3"
       },
       "engines": {
@@ -1015,6 +1016,41 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
+      "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.1.tgz",
+      "integrity": "sha512-Wp5vwlZ0lOqpSYGKqr53INws9HLkt6JDc/pDZcPf7bchQnrXJMXPns8CXx0hFikMSGSWfvtvvpb2gtMVfkWagA==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.1.1.tgz",
+      "integrity": "sha512-cZ7rKJTLiE7u7Wi/v9Hc2fs3Ucc3jrWeMgPHbbTCeVAB2S0wOBbYlkJVeNSL04i7fdhT8wIbDq1zhC/PXTD2SA==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
     },
     "node_modules/@szmarczak/http-timer": {
       "version": "1.1.2",
@@ -3905,6 +3941,12 @@
         "semver": "bin/semver"
       }
     },
+    "node_modules/just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
+    },
     "node_modules/jwa": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
@@ -4023,6 +4065,12 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+      "dev": true
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
     "node_modules/lodash.includes": {
@@ -4438,6 +4486,28 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
+    },
+    "node_modules/nise": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.1.tgz",
+      "integrity": "sha512-yr5kW2THW1AkxVmCnKEh4nbYkJdB3I7LUkiUgOvEkOp414mc2UMaHMA7pjq1nYowhdoJZGwEKGaQVbxfpWj10A==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": ">=5",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
+    },
+    "node_modules/nise/node_modules/path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "dependencies": {
+        "isarray": "0.0.1"
+      }
     },
     "node_modules/nock": {
       "version": "13.2.2",
@@ -5932,6 +6002,24 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.6.tgz",
       "integrity": "sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==",
       "dev": true
+    },
+    "node_modules/sinon": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-13.0.1.tgz",
+      "integrity": "sha512-8yx2wIvkBjIq/MGY1D9h1LMraYW+z1X0mb648KZnKSdvLasvDu7maa0dFaNYdTDczFgbjNw2tOmWdTk9saVfwQ==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": "^9.0.0",
+        "@sinonjs/samsam": "^6.1.1",
+        "diff": "^5.0.0",
+        "nise": "^5.1.1",
+        "supports-color": "^7.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
     },
     "node_modules/slice-ansi": {
       "version": "4.0.0",
@@ -7484,6 +7572,41 @@
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
       "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
+      "dev": true
+    },
+    "@sinonjs/commons": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
+      "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.1.tgz",
+      "integrity": "sha512-Wp5vwlZ0lOqpSYGKqr53INws9HLkt6JDc/pDZcPf7bchQnrXJMXPns8CXx0hFikMSGSWfvtvvpb2gtMVfkWagA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.1.1.tgz",
+      "integrity": "sha512-cZ7rKJTLiE7u7Wi/v9Hc2fs3Ucc3jrWeMgPHbbTCeVAB2S0wOBbYlkJVeNSL04i7fdhT8wIbDq1zhC/PXTD2SA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
     },
     "@szmarczak/http-timer": {
@@ -9762,6 +9885,12 @@
         }
       }
     },
+    "just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
+    },
     "jwa": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
@@ -9859,6 +9988,12 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+      "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
     "lodash.includes": {
@@ -10189,6 +10324,30 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
+    },
+    "nise": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.1.tgz",
+      "integrity": "sha512-yr5kW2THW1AkxVmCnKEh4nbYkJdB3I7LUkiUgOvEkOp414mc2UMaHMA7pjq1nYowhdoJZGwEKGaQVbxfpWj10A==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": ">=5",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      },
+      "dependencies": {
+        "path-to-regexp": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "dev": true,
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
     },
     "nock": {
       "version": "13.2.2",
@@ -11362,6 +11521,20 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.6.tgz",
       "integrity": "sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==",
       "dev": true
+    },
+    "sinon": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-13.0.1.tgz",
+      "integrity": "sha512-8yx2wIvkBjIq/MGY1D9h1LMraYW+z1X0mb648KZnKSdvLasvDu7maa0dFaNYdTDczFgbjNw2tOmWdTk9saVfwQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": "^9.0.0",
+        "@sinonjs/samsam": "^6.1.1",
+        "diff": "^5.0.0",
+        "nise": "^5.1.1",
+        "supports-color": "^7.2.0"
+      }
     },
     "slice-ansi": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dscp-api",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "DSCP API",
   "repository": {
     "type": "git",
@@ -19,6 +19,7 @@
   "main": "./app/index.js",
   "scripts": {
     "test": "NODE_ENV=test mocha --config ./test/mocharc.js ./test",
+    "test:unit": "NODE_ENV=test mocha --config ./test/mocharc.js ./test/unit",
     "test:integration": "NODE_ENV=test mocha --config ./test/mocharc.js ./test/integration",
     "lint": "eslint .",
     "start": "NODE_ENV=production node app/index.js",
@@ -59,6 +60,7 @@
     "nyc": "^15.1.0",
     "pino-colada": "^2.1.0",
     "prettier": "^2.3.1",
+    "sinon": "^13.0.1",
     "supertest": "^6.1.3"
   }
 }

--- a/test/integration/regressions.test.js
+++ b/test/integration/regressions.test.js
@@ -20,6 +20,7 @@ describe('Bug regression tests', function () {
     let app
     let jwksMock
     let authToken
+    let statusHandler
 
     before(async () => {
       nock.disableNetConnect()
@@ -32,7 +33,9 @@ describe('Bug regression tests', function () {
     })
 
     before(async function () {
-      app = await createHttpServer()
+      const server = await createHttpServer()
+      app = server.app
+      statusHandler = server.statusHandler
 
       jwksMock = createJWKSMock(AUTH_ISSUER)
       jwksMock.start()
@@ -44,6 +47,10 @@ describe('Bug regression tests', function () {
 
     after(async function () {
       await jwksMock.stop()
+    })
+
+    after(function () {
+      statusHandler.close()
     })
 
     test('add and get item - single metadata FILE', async function () {

--- a/test/integration/routes.test.js
+++ b/test/integration/routes.test.js
@@ -65,7 +65,24 @@ describe('routes', function () {
     })
 
     test('health check', async function () {
-      const expectedResult = { status: 'ok', version: API_VERSION, detail: { api: {} } }
+      const expectedResult = {
+        status: 'ok',
+        version: API_VERSION,
+        detail: {
+          api: {
+            chain: 'Development',
+            runtime: {
+              name: 'dscp',
+              versions: {
+                authoring: 1,
+                impl: 1,
+                spec: 300,
+                transaction: 1,
+              },
+            },
+          },
+        },
+      }
 
       const actualResult = await healthCheck(app)
       expect(actualResult.status).to.equal(200)

--- a/test/integration/routes.test.js
+++ b/test/integration/routes.test.js
@@ -52,10 +52,16 @@ describe('routes', function () {
   })
 
   describe('health check', function () {
-    let app
+    let app, statusHandler
 
     before(async function () {
-      app = await createHttpServer()
+      const server = await createHttpServer()
+      app = server.app
+      statusHandler = server.statusHandler
+    })
+
+    after(function () {
+      statusHandler.close()
     })
 
     test('health check', async function () {
@@ -69,7 +75,7 @@ describe('routes', function () {
 
   describe('access token', async () => {
     // Inputs
-    let app
+    let app, statusHandler
     const tokenResponse = {
       data: {
         access_token: 'fake access token',
@@ -79,8 +85,14 @@ describe('routes', function () {
     }
 
     before(async () => {
-      app = await createHttpServer()
+      const server = await createHttpServer()
+      app = server.app
+      statusHandler = server.statusHandler
       nock(AUTH_TOKEN_URL).post(`/`).reply(200, tokenResponse)
+    })
+
+    after(function () {
+      statusHandler.close()
     })
 
     test('get access token', async () => {
@@ -96,12 +108,18 @@ describe('routes', function () {
 
   describe('invalid credentials', async () => {
     // Inputs
-    let app
+    let app, statusHandler
     const deniedResponse = { error: 'Unauthorised' }
 
     before(async () => {
-      app = await createHttpServer()
+      const server = await createHttpServer()
+      app = server.app
+      statusHandler = server.statusHandler
       nock(AUTH_TOKEN_URL).post(`/`).reply(401, deniedResponse)
+    })
+
+    after(function () {
+      statusHandler.close()
     })
 
     test('access denied to token', async () => {
@@ -122,10 +140,13 @@ describe('routes', function () {
     let app
     let jwksMock
     let authToken
+    let statusHandler
     const process = {}
 
     before(async function () {
-      app = await createHttpServer()
+      const server = await createHttpServer()
+      app = server.app
+      statusHandler = server.statusHandler
 
       jwksMock = createJWKSMock(AUTH_ISSUER)
       jwksMock.start()
@@ -137,6 +158,10 @@ describe('routes', function () {
 
     after(async function () {
       await jwksMock.stop()
+    })
+
+    after(function () {
+      statusHandler.close()
     })
 
     withNewTestProcess(process)

--- a/test/integration/routes.test.js
+++ b/test/integration/routes.test.js
@@ -59,7 +59,7 @@ describe('routes', function () {
     })
 
     test('health check', async function () {
-      const expectedResult = { status: 'ok', version: API_VERSION }
+      const expectedResult = { status: 'ok', version: API_VERSION, detail: { api: {} } }
 
       const actualResult = await healthCheck(app)
       expect(actualResult.status).to.equal(200)

--- a/test/unit/util/statusPoll.test.js
+++ b/test/unit/util/statusPoll.test.js
@@ -1,0 +1,168 @@
+const { describe, beforeEach, afterEach, it } = require('mocha')
+const sinon = require('sinon')
+const { expect } = require('chai')
+
+const { serviceState, startStatusHandler, buildCombinedHandler } = require('../../../app/util/statusPoll')
+
+const okStatus = (i) => ({
+  status: serviceState.UP,
+  detail: i,
+})
+
+const withFakeTimesForEvery = function () {
+  beforeEach(function () {
+    this.clock = sinon.useFakeTimers()
+  })
+  afterEach(function () {
+    this.clock.restore()
+  })
+}
+
+const stopAfterEvery = function () {
+  afterEach(function () {
+    if (this.handler) {
+      this.handler.close()
+    }
+  })
+}
+
+const period = 1000
+
+describe('startStatusHandler', function () {
+  withFakeTimesForEvery()
+  stopAfterEvery()
+
+  it('should get the service status immediately', async function () {
+    this.handler = await startStatusHandler({ pollingPeriodMs: 1000, getStatus: sinon.stub().resolves(okStatus(0)) })
+    const status = this.handler.status
+    const detail = this.handler.detail
+    expect(status).to.deep.equal(serviceState.UP)
+    expect(detail).to.deep.equal(0)
+  })
+
+  it('should poll status every period', async function () {
+    this.handler = await startStatusHandler({
+      pollingPeriodMs: period,
+      getStatus: Array(10)
+        .fill(null)
+        .reduce((stub, _, i) => {
+          return stub.onCall(i).resolves(okStatus(i))
+        }, sinon.stub()),
+    })
+    await this.clock.tickAsync(period / 2)
+    for (let i = 0; i < 10; i++) {
+      await this.clock.tickAsync(period / 2)
+      const status = this.handler.status
+      const detail = this.handler.detail
+      expect(status).to.deep.equal(serviceState.UP)
+      expect(detail).to.deep.equal(1 + (i >> 1))
+    }
+  })
+
+  it('should report status error if poll handler throws', async function () {
+    this.handler = await startStatusHandler({ pollingPeriodMs: 1000, getStatus: sinon.stub().rejects(new Error()) })
+    const status = this.handler.status
+    expect(status).to.deep.equal(serviceState.ERROR)
+    const detail = this.handler.detail
+    expect(detail).to.deep.equal(null)
+  })
+
+  it('should report status error if poll handler returns jibberish', async function () {
+    this.handler = await startStatusHandler({ pollingPeriodMs: 1000, getStatus: sinon.stub().resolves('jibberish') })
+    const status = this.handler.status
+    expect(status).to.deep.equal(serviceState.ERROR)
+    const detail = this.handler.detail
+    expect(detail).to.deep.equal(null)
+  })
+
+  it('should report status error if poll handler returns an invalid status', async function () {
+    this.handler = await startStatusHandler({
+      pollingPeriodMs: 1000,
+      getStatus: sinon.stub().resolves({ status: 'invalid' }),
+    })
+    const status = this.handler.status
+    expect(status).to.deep.equal(serviceState.ERROR)
+    const detail = this.handler.detail
+    expect(detail).to.deep.equal(null)
+  })
+
+  it('should not allow detail to be undefined', async function () {
+    this.handler = await startStatusHandler({
+      pollingPeriodMs: 1000,
+      getStatus: sinon.stub().resolves({ status: serviceState.UP }),
+    })
+    const status = this.handler.status
+    const detail = this.handler.detail
+    expect(status).to.deep.equal(serviceState.UP)
+    expect(detail).to.deep.equal(null)
+  })
+
+  it('should not poll after calling stop', async function () {
+    this.handler = await startStatusHandler({
+      pollingPeriodMs: period,
+      getStatus: Array(10)
+        .fill(null)
+        .reduce((stub, _, i) => {
+          return stub.onCall(i).resolves(okStatus(i))
+        }, sinon.stub()),
+    })
+    await this.clock.tickAsync(period / 2)
+    for (let i = 0; i < 5; i++) {
+      await this.clock.tickAsync(period / 2)
+      const status = this.handler.status
+      const detail = this.handler.detail
+      expect(status).to.deep.equal(serviceState.UP)
+      expect(detail).to.deep.equal(1 + (i >> 1))
+    }
+    this.handler.close()
+    for (let i = 5; i < 10; i++) {
+      await this.clock.tickAsync(period / 2)
+      const status = this.handler.status
+      const detail = this.handler.detail
+      expect(status).to.deep.equal(serviceState.UP)
+      expect(detail).to.deep.equal(1 + (5 >> 1))
+    }
+  })
+})
+
+describe('buildCombinedHandler', function () {
+  it('should combine multiple UP statuses to UP', async function () {
+    const handlersMap = new Map([
+      ['a', { status: serviceState.UP, detail: 1 }],
+      ['b', { status: serviceState.UP, detail: 2 }],
+    ])
+    const result = await buildCombinedHandler(handlersMap)
+    expect(result.status).to.equal(serviceState.UP)
+    expect(result.detail).to.deep.equal({ a: 1, b: 2 })
+  })
+
+  it('should combine UP and DOWN statuses to DOWN', async function () {
+    const handlersMap = new Map([
+      ['a', { status: serviceState.UP, detail: 1 }],
+      ['b', { status: serviceState.DOWN, detail: 2 }],
+    ])
+    const result = await buildCombinedHandler(handlersMap)
+    expect(result.status).to.equal(serviceState.DOWN)
+    expect(result.detail).to.deep.equal({ a: 1, b: 2 })
+  })
+
+  it('should combine UP and ERROR statuses to ERROR', async function () {
+    const handlersMap = new Map([
+      ['a', { status: serviceState.UP, detail: 1 }],
+      ['b', { status: serviceState.ERROR, detail: 2 }],
+    ])
+    const result = await buildCombinedHandler(handlersMap)
+    expect(result.status).to.equal(serviceState.ERROR)
+    expect(result.detail).to.deep.equal({ a: 1, b: 2 })
+  })
+
+  it('should combine DOWN and ERROR statuses to DOWN', async function () {
+    const handlersMap = new Map([
+      ['a', { status: serviceState.DOWN, detail: 1 }],
+      ['b', { status: serviceState.ERROR, detail: 2 }],
+    ])
+    const result = await buildCombinedHandler(handlersMap)
+    expect(result.status).to.equal(serviceState.DOWN)
+    expect(result.detail).to.deep.equal({ a: 1, b: 2 })
+  })
+})


### PR DESCRIPTION
Implements status handling infrastructure. This allows multiple polling status handlers to exist for different dependencies. The status and detail for these are then combined to form an overall service status which is served by the health endpoint

At the moment a basic healthcheck is implmented for substrate