### PR TITLE
Improve substrate healthcheck

### DIFF
--- a/app/server.js
+++ b/app/server.js
@@ -31,9 +31,21 @@ async function createHttpServer() {
   }
   app.get('/health', async (req, res) => {
     const status = statusHandler.status
-    const detail = statusHandler.detail
+    const details = statusHandler.detail
     const code = status === serviceState.UP ? 200 : 503
-    res.status(code).send({ version: API_VERSION, status: serviceStatusStrings[status] || 'error', detail })
+    res.status(code).send({
+      version: API_VERSION,
+      status: serviceStatusStrings[status] || 'error',
+      details: Object.fromEntries(
+        Object.entries(details).map(([depName, { status, detail }]) => [
+          depName,
+          {
+            status: serviceStatusStrings[status] || 'error',
+            detail,
+          },
+        ])
+      ),
+    })
   })
 
   app.use((req, res, next) => {

--- a/app/serviceStatus/apiStatus.js
+++ b/app/serviceStatus/apiStatus.js
@@ -3,22 +3,35 @@ const { substrateApi } = require('../util/substrateApi')
 const { SUBSTRATE_STATUS_POLL_PERIOD_MS, SUBSTRATE_STATUS_TIMEOUT_MS } = require('../env')
 
 const getStatus = async () => {
-  await substrateApi.isReady
-  const [chain, runtime] = await Promise.all([substrateApi.runtimeChain, substrateApi.runtimeVersion])
-  return {
-    status: serviceState.UP,
-    detail: {
-      chain,
-      runtime: {
-        name: runtime.specName,
-        versions: {
-          spec: runtime.specVersion.toNumber(),
-          impl: runtime.implVersion.toNumber(),
-          authoring: runtime.authoringVersion.toNumber(),
-          transaction: runtime.transactionVersion.toNumber(),
+  try {
+    await substrateApi.isReadyOrError
+    const [chain, runtime] = await Promise.all([substrateApi.runtimeChain, substrateApi.runtimeVersion])
+    return {
+      status: serviceState.UP,
+      detail: {
+        chain,
+        runtime: {
+          name: runtime.specName,
+          versions: {
+            spec: runtime.specVersion.toNumber(),
+            impl: runtime.implVersion.toNumber(),
+            authoring: runtime.authoringVersion.toNumber(),
+            transaction: runtime.transactionVersion.toNumber(),
+          },
         },
       },
-    },
+    }
+  } catch (err) {
+    return {
+      status: serviceState.DOWN,
+      detail: !substrateApi.isConnected
+        ? {
+            message: 'Cannot connect to substrate node',
+          }
+        : {
+            message: 'Unknown error getting status from substrate node',
+          },
+    }
   }
 }
 

--- a/app/util/statusPoll.js
+++ b/app/util/statusPoll.js
@@ -80,7 +80,7 @@ const buildCombinedHandler = async (handlerMap) => {
       return getStatus()
     },
     get detail() {
-      return Object.fromEntries([...handlerMap].map(([name, { detail }]) => [name, detail]))
+      return Object.fromEntries([...handlerMap])
     },
     close: () => {
       for (const handler of handlerMap.values()) {

--- a/app/util/substrateApi.js
+++ b/app/util/substrateApi.js
@@ -80,6 +80,7 @@ const apiOptions = {
 }
 
 const api = new ApiPromise(apiOptions)
+api.isReadyOrError.catch(() => {})
 
 api.on('disconnected', () => {
   logger.warn(`Disconnected from substrate node at ${API_HOST}:${API_PORT}`)

--- a/helm/dscp-api/Chart.yaml
+++ b/helm/dscp-api/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: dscp-api
-appVersion: '4.0.2'
+appVersion: '4.0.3'
 description: A Helm chart for dscp-api
-version: '4.0.2'
+version: '4.0.3'
 type: application
 dependencies:
   - name: dscp-node

--- a/helm/dscp-api/values.yaml
+++ b/helm/dscp-api/values.yaml
@@ -24,7 +24,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/digicatapult/dscp-api
   pullPolicy: IfNotPresent
-  tag: 'v4.0.2'
+  tag: 'v4.0.3'
 
 dscpNode:
   enabled: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dscp-api",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dscp-api",
-      "version": "4.0.2",
+      "version": "4.0.3",
       "license": "ISC",
       "dependencies": {
         "@polkadot/api": "^5.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dscp-api",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "DSCP API",
   "repository": {
     "type": "git",

--- a/test/integration/routes.test.js
+++ b/test/integration/routes.test.js
@@ -68,16 +68,19 @@ describe('routes', function () {
       const expectedResult = {
         status: 'ok',
         version: API_VERSION,
-        detail: {
+        details: {
           api: {
-            chain: 'Development',
-            runtime: {
-              name: 'dscp',
-              versions: {
-                authoring: 1,
-                impl: 1,
-                spec: 300,
-                transaction: 1,
+            status: 'ok',
+            detail: {
+              chain: 'Development',
+              runtime: {
+                name: 'dscp',
+                versions: {
+                  authoring: 1,
+                  impl: 1,
+                  spec: 300,
+                  transaction: 1,
+                },
               },
             },
           },

--- a/test/unit/util/statusPoll.test.js
+++ b/test/unit/util/statusPoll.test.js
@@ -169,7 +169,16 @@ describe('buildCombinedHandler', function () {
     ])
     const result = await buildCombinedHandler(handlersMap)
     expect(result.status).to.equal(serviceState.UP)
-    expect(result.detail).to.deep.equal({ a: 1, b: 2 })
+    expect(result.detail).to.deep.equal({
+      a: {
+        status: serviceState.UP,
+        detail: 1,
+      },
+      b: {
+        status: serviceState.UP,
+        detail: 2,
+      },
+    })
   })
 
   it('should combine UP and DOWN statuses to DOWN', async function () {
@@ -179,7 +188,16 @@ describe('buildCombinedHandler', function () {
     ])
     const result = await buildCombinedHandler(handlersMap)
     expect(result.status).to.equal(serviceState.DOWN)
-    expect(result.detail).to.deep.equal({ a: 1, b: 2 })
+    expect(result.detail).to.deep.equal({
+      a: {
+        status: serviceState.UP,
+        detail: 1,
+      },
+      b: {
+        status: serviceState.DOWN,
+        detail: 2,
+      },
+    })
   })
 
   it('should combine UP and ERROR statuses to ERROR', async function () {
@@ -189,7 +207,16 @@ describe('buildCombinedHandler', function () {
     ])
     const result = await buildCombinedHandler(handlersMap)
     expect(result.status).to.equal(serviceState.ERROR)
-    expect(result.detail).to.deep.equal({ a: 1, b: 2 })
+    expect(result.detail).to.deep.equal({
+      a: {
+        status: serviceState.UP,
+        detail: 1,
+      },
+      b: {
+        status: serviceState.ERROR,
+        detail: 2,
+      },
+    })
   })
 
   it('should combine DOWN and ERROR statuses to DOWN', async function () {
@@ -199,6 +226,15 @@ describe('buildCombinedHandler', function () {
     ])
     const result = await buildCombinedHandler(handlersMap)
     expect(result.status).to.equal(serviceState.DOWN)
-    expect(result.detail).to.deep.equal({ a: 1, b: 2 })
+    expect(result.detail).to.deep.equal({
+      a: {
+        status: serviceState.DOWN,
+        detail: 1,
+      },
+      b: {
+        status: serviceState.ERROR,
+        detail: 2,
+      },
+    })
   })
 })


### PR DESCRIPTION
Improves the service healthcheck. Notably:

* gets summary status per service in `details` property of `/health` response
* no longer crashes if cannot connect to substrate (sorry haven't had time to get an integration test in for this yet)
* Some sort of error message in `detail` when we cannot connect to the substrate node or some other error occurs. Annoyingly the error thrown be substrate when it cannot connect isn't an `Error` and has no message. This is therefore quite crude atm
