### PR TITLE
Fix substrate healthcheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,25 +52,27 @@ npm run test:integration
 
 The following environment variables are used by `dscp-api` and can be configured. Entries marked as `required` are needed when running `dscp-api` in production mode.
 
-| variable                      | required |                       default                       | description                                                                                  |
-| :---------------------------- | :------: | :-------------------------------------------------: | :------------------------------------------------------------------------------------------- |
-| PORT                          |    N     |                       `3001`                        | The port for the API to listen on                                                            |
-| API_HOST                      |    Y     |                          -                          | The hostname of the `dscp-node` the API should connect to                                    |
-| API_PORT                      |    N     |                       `9944`                        | The port of the `dscp-node` the API should connect to                                        |
-| LOG_LEVEL                     |    N     |                       `info`                        | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`]         |
-| USER_URI                      |    Y     |                          -                          | The Substrate `URI` representing the private key to use when making `dscp-node` transactions |
-| IPFS_HOST                     |    Y     |                          -                          | Hostname of the `IPFS` node to use for metadata storage                                      |
-| IPFS_PORT                     |    N     |                       `15001`                       | Port of the `IPFS` node to use for metadata storage                                          |
-| AUTH_JWKS_URI                 |    N     | `https://inteli.eu.auth0.com/.well-known/jwks.json` | JSON Web Key Set containing public keys used by the Auth0 API                                |
-| AUTH_AUDIENCE                 |    N     |                    `inteli-dev`                     | Identifier of the Auth0 API                                                                  |
-| AUTH_ISSUER                   |    N     |           `https://inteli.eu.auth0.com/`            | Domain of the Auth0 API `                                                                    |
-| AUTH_TOKEN_URL                |    N     |      `https://inteli.eu.auth0.com/oauth/token`      | Auth0 API endpoint that issues an Authorisation (Bearer) access token                        |
-| METADATA_KEY_LENGTH           |    N     |                        `32`                         | Fixed length of metadata keys                                                                |
-| METADATA_VALUE_LITERAL_LENGTH |    N     |                        `32`                         | Fixed length of metadata LITERAL values                                                      |
-| MAX_METADATA_COUNT            |    N     |                        `16`                         | Maximum number of metadata items allowed per token                                           |
-| API_VERSION                   |    N     |               `package.json version`                | API version                                                                                  |
-| API_MAJOR_VERSION             |    N     |                        `v3`                         | API major version                                                                            |
-| FILE_UPLOAD_MAX_SIZE          |    N     |                 `200 * 1024 * 1024`                 | The Maximum file upload size (bytes)                                                         |
+| variable                        | required |                       default                       | description                                                                                  |
+| :------------------------------ | :------: | :-------------------------------------------------: | :------------------------------------------------------------------------------------------- |
+| PORT                            |    N     |                       `3001`                        | The port for the API to listen on                                                            |
+| API_HOST                        |    Y     |                          -                          | The hostname of the `dscp-node` the API should connect to                                    |
+| API_PORT                        |    N     |                       `9944`                        | The port of the `dscp-node` the API should connect to                                        |
+| LOG_LEVEL                       |    N     |                       `info`                        | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`]         |
+| USER_URI                        |    Y     |                          -                          | The Substrate `URI` representing the private key to use when making `dscp-node` transactions |
+| IPFS_HOST                       |    Y     |                          -                          | Hostname of the `IPFS` node to use for metadata storage                                      |
+| IPFS_PORT                       |    N     |                       `15001`                       | Port of the `IPFS` node to use for metadata storage                                          |
+| AUTH_JWKS_URI                   |    N     | `https://inteli.eu.auth0.com/.well-known/jwks.json` | JSON Web Key Set containing public keys used by the Auth0 API                                |
+| AUTH_AUDIENCE                   |    N     |                    `inteli-dev`                     | Identifier of the Auth0 API                                                                  |
+| AUTH_ISSUER                     |    N     |           `https://inteli.eu.auth0.com/`            | Domain of the Auth0 API `                                                                    |
+| AUTH_TOKEN_URL                  |    N     |      `https://inteli.eu.auth0.com/oauth/token`      | Auth0 API endpoint that issues an Authorisation (Bearer) access token                        |
+| METADATA_KEY_LENGTH             |    N     |                        `32`                         | Fixed length of metadata keys                                                                |
+| METADATA_VALUE_LITERAL_LENGTH   |    N     |                        `32`                         | Fixed length of metadata LITERAL values                                                      |
+| MAX_METADATA_COUNT              |    N     |                        `16`                         | Maximum number of metadata items allowed per token                                           |
+| API_VERSION                     |    N     |               `package.json version`                | API version                                                                                  |
+| API_MAJOR_VERSION               |    N     |                        `v3`                         | API major version                                                                            |
+| FILE_UPLOAD_MAX_SIZE            |    N     |                 `200 * 1024 * 1024`                 | The Maximum file upload size (bytes)                                                         |
+| SUBSTRATE_STATUS_POLL_PERIOD_MS |    N     |                     `10 * 1000`                     | Number of ms between calls to check dscp-node status                                         |
+| SUBSTRATE_STATUS_TIMEOUT_MS     |    N     |                     `2 * 1000`                      | Number of ms to wait for response to dscp-node health requests                               |
 
 ## Running the API
 

--- a/app/env.js
+++ b/app/env.js
@@ -28,7 +28,7 @@ const vars = envalid.cleanEnv(process.env, {
   API_VERSION: envalid.str({ default: version }),
   API_MAJOR_VERSION: envalid.str({ default: 'v3' }),
   FILE_UPLOAD_MAX_SIZE: envalid.num({ default: 200 * 1024 * 1024 }),
-  SUBSTRATE_STATUS_POLL_PERIOD_MS: envalid.num({ default: 30 * 1000 }),
+  SUBSTRATE_STATUS_POLL_PERIOD_MS: envalid.num({ default: 10 * 1000 }),
   SUBSTRATE_STATUS_TIMEOUT_MS: envalid.num({ default: 2 * 1000 }),
 })
 

--- a/app/serviceStatus/apiStatus.js
+++ b/app/serviceStatus/apiStatus.js
@@ -3,35 +3,29 @@ const { substrateApi } = require('../util/substrateApi')
 const { SUBSTRATE_STATUS_POLL_PERIOD_MS, SUBSTRATE_STATUS_TIMEOUT_MS } = require('../env')
 
 const getStatus = async () => {
-  try {
-    await substrateApi.isReadyOrError
-    const [chain, runtime] = await Promise.all([substrateApi.runtimeChain, substrateApi.runtimeVersion])
-    return {
-      status: serviceState.UP,
-      detail: {
-        chain,
-        runtime: {
-          name: runtime.specName,
-          versions: {
-            spec: runtime.specVersion.toNumber(),
-            impl: runtime.implVersion.toNumber(),
-            authoring: runtime.authoringVersion.toNumber(),
-            transaction: runtime.transactionVersion.toNumber(),
-          },
-        },
-      },
-    }
-  } catch (err) {
+  if (!substrateApi.isConnected) {
     return {
       status: serviceState.DOWN,
-      detail: !substrateApi.isConnected
-        ? {
-            message: 'Cannot connect to substrate node',
-          }
-        : {
-            message: 'Unknown error getting status from substrate node',
-          },
+      detail: {
+        message: 'Cannot connect to substrate node',
+      },
     }
+  }
+  const [chain, runtime] = await Promise.all([substrateApi.runtimeChain, substrateApi.runtimeVersion])
+  return {
+    status: serviceState.UP,
+    detail: {
+      chain,
+      runtime: {
+        name: runtime.specName,
+        versions: {
+          spec: runtime.specVersion.toNumber(),
+          impl: runtime.implVersion.toNumber(),
+          authoring: runtime.authoringVersion.toNumber(),
+          transaction: runtime.transactionVersion.toNumber(),
+        },
+      },
+    },
   }
 }
 

--- a/app/serviceStatus/apiStatus.js
+++ b/app/serviceStatus/apiStatus.js
@@ -3,6 +3,7 @@ const { substrateApi } = require('../util/substrateApi')
 const { SUBSTRATE_STATUS_POLL_PERIOD_MS, SUBSTRATE_STATUS_TIMEOUT_MS } = require('../env')
 
 const getStatus = async () => {
+  await substrateApi.isReadyOrError.catch(() => {})
   if (!substrateApi.isConnected) {
     return {
       status: serviceState.DOWN,

--- a/helm/dscp-api/Chart.yaml
+++ b/helm/dscp-api/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: dscp-api
-appVersion: '4.0.3'
+appVersion: '4.0.4'
 description: A Helm chart for dscp-api
-version: '4.0.3'
+version: '4.0.4'
 type: application
 dependencies:
   - name: dscp-node

--- a/helm/dscp-api/templates/configmap.yaml
+++ b/helm/dscp-api/templates/configmap.yaml
@@ -22,5 +22,5 @@ data:
   authAudience: {{ .Values.config.auth.audience }}
   authIssuer: {{ .Values.config.auth.issuer }}
   authTokenUrl: {{ .Values.config.auth.tokenUrl }}
-  substrateStatusPollPeriodMs: {{ .Values.config.substrateStatusPollPeriodMs }}
-  substrateStatusTimeoutMs: {{ .Values.config.substrateStatusTimeoutMs }}
+  substrateStatusPollPeriodMs: {{ .Values.config.substrateStatusPollPeriodMs | quote }}
+  substrateStatusTimeoutMs: {{ .Values.config.substrateStatusTimeoutMs | quote }}

--- a/helm/dscp-api/templates/configmap.yaml
+++ b/helm/dscp-api/templates/configmap.yaml
@@ -22,3 +22,5 @@ data:
   authAudience: {{ .Values.config.auth.audience }}
   authIssuer: {{ .Values.config.auth.issuer }}
   authTokenUrl: {{ .Values.config.auth.tokenUrl }}
+  substrateStatusPollPeriodMs: {{ .Values.config.substrateStatusPollPeriodMs }}
+  substrateStatusTimeoutMs: {{ .Values.config.substrateStatusTimeoutMs }}

--- a/helm/dscp-api/templates/deployment.yaml
+++ b/helm/dscp-api/templates/deployment.yaml
@@ -70,6 +70,16 @@ spec:
                 configMapKeyRef:
                   name: {{ include "dscp-api.fullname" . }}-config
                   key: authTokenUrl
+            - name: SUBSTRATE_STATUS_POLL_PERIOD_MS
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "dscp-api.fullname" . }}-config
+                  key: substrateStatusPollPeriodMs
+            - name: SUBSTRATE_STATUS_TIMEOUT_MS
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "dscp-api.fullname" . }}-config
+                  key: substrateStatusTimeoutMs
             - name: USER_URI
               valueFrom:
                 secretKeyRef:

--- a/helm/dscp-api/values.yaml
+++ b/helm/dscp-api/values.yaml
@@ -24,7 +24,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/digicatapult/dscp-api
   pullPolicy: IfNotPresent
-  tag: 'v4.0.3'
+  tag: 'v4.0.4'
 
 dscpNode:
   enabled: false

--- a/helm/dscp-api/values.yaml
+++ b/helm/dscp-api/values.yaml
@@ -7,6 +7,8 @@ config:
   # externalIpfsHost: "" # This overrides dscpIpfs.enabled when setting the IPFS_HOST envar
   # externalIpfsPort: 5001 # This overrides dscpIpfs.enabled when setting the IPFS_PORT envar
   enableLivenessProbe: true
+  substrateStatusPollPeriodMs: 10000
+  substrateStatusTimeoutMs: 2000
   auth:
     jwksUri: https://inteli.eu.auth0.com/.well-known/jwks.json
     audience: inteli-dev

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dscp-api",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dscp-api",
-      "version": "4.0.3",
+      "version": "4.0.4",
       "license": "ISC",
       "dependencies": {
         "@polkadot/api": "^5.9.1",
@@ -4425,9 +4425,9 @@
       }
     },
     "node_modules/moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
+      "version": "2.29.2",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.2.tgz",
+      "integrity": "sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==",
       "dev": true,
       "engines": {
         "node": "*"
@@ -10278,9 +10278,9 @@
       }
     },
     "moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
+      "version": "2.29.2",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.2.tgz",
+      "integrity": "sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==",
       "dev": true
     },
     "ms": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dscp-api",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "DSCP API",
   "repository": {
     "type": "git",

--- a/test/helper/healthcheckFixtures.js
+++ b/test/helper/healthcheckFixtures.js
@@ -1,0 +1,47 @@
+const { API_VERSION } = require('../../app/env')
+
+const responses = {
+  ok: {
+    code: 200,
+    body: {
+      status: 'ok',
+      version: API_VERSION,
+      details: {
+        api: {
+          status: 'ok',
+          detail: {
+            chain: 'Development',
+            runtime: {
+              name: 'dscp',
+              versions: {
+                authoring: 1,
+                impl: 1,
+                spec: 300,
+                transaction: 1,
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  down: {
+    code: 503,
+    body: {
+      status: 'down',
+      version: API_VERSION,
+      details: {
+        api: {
+          status: 'down',
+          detail: {
+            message: 'Cannot connect to substrate node',
+          },
+        },
+      },
+    },
+  },
+}
+
+module.exports = {
+  responses,
+}

--- a/test/integration/routes.test.js
+++ b/test/integration/routes.test.js
@@ -51,7 +51,7 @@ describe('routes', function () {
     nock.cleanAll()
   })
 
-  describe('health check', function () {
+  describe.only('health check', function () {
     let app, statusHandler
 
     before(async function () {

--- a/test/integration/routes.test.js
+++ b/test/integration/routes.test.js
@@ -33,9 +33,10 @@ const {
   METADATA_KEY_LENGTH,
   METADATA_VALUE_LITERAL_LENGTH,
   MAX_METADATA_COUNT,
-  API_VERSION,
   PROCESS_IDENTIFIER_LENGTH,
 } = require('../../app/env')
+
+const { responses: healthcheckResponses } = require('../helper/healthcheckFixtures')
 
 const { substrateApi } = require('../../app/util/substrateApi')
 
@@ -69,31 +70,10 @@ describe('routes', function () {
       })
 
       test('health check', async function () {
-        const expectedResult = {
-          status: 'ok',
-          version: API_VERSION,
-          details: {
-            api: {
-              status: 'ok',
-              detail: {
-                chain: 'Development',
-                runtime: {
-                  name: 'dscp',
-                  versions: {
-                    authoring: 1,
-                    impl: 1,
-                    spec: 300,
-                    transaction: 1,
-                  },
-                },
-              },
-            },
-          },
-        }
-
+        const response = healthcheckResponses.ok
         const actualResult = await healthCheck(app)
-        expect(actualResult.status).to.equal(200)
-        expect(actualResult.body).to.deep.equal(expectedResult)
+        expect(actualResult.status).to.equal(response.code)
+        expect(actualResult.body).to.deep.equal(response.body)
       })
     })
 
@@ -124,22 +104,10 @@ describe('routes', function () {
       })
 
       test('service down', async function () {
-        const expectedResult = {
-          status: 'down',
-          version: API_VERSION,
-          details: {
-            api: {
-              status: 'down',
-              detail: {
-                message: 'Cannot connect to substrate node',
-              },
-            },
-          },
-        }
-
+        const response = healthcheckResponses.down
         const actualResult = await healthCheck(app)
-        expect(actualResult.status).to.equal(503)
-        expect(actualResult.body).to.deep.equal(expectedResult)
+        expect(actualResult.status).to.equal(response.code)
+        expect(actualResult.body).to.deep.equal(response.body)
       })
     })
 
@@ -177,32 +145,10 @@ describe('routes', function () {
       })
 
       test('service up', async function () {
-        const expectedResult = {
-          status: 'ok',
-          version: API_VERSION,
-          details: {
-            api: {
-              status: 'ok',
-              detail: {
-                chain: 'Development',
-                runtime: {
-                  name: 'dscp',
-                  versions: {
-                    authoring: 1,
-                    impl: 1,
-                    spec: 300,
-                    transaction: 1,
-                  },
-                },
-              },
-            },
-          },
-        }
-
-        await this.clock.tickAsync(10000)
+        const response = healthcheckResponses.ok
         const actualResult = await healthCheck(app)
-        expect(actualResult.status).to.equal(200)
-        expect(actualResult.body).to.deep.equal(expectedResult)
+        expect(actualResult.status).to.equal(response.code)
+        expect(actualResult.body).to.deep.equal(response.body)
       })
     })
   })

--- a/test/integration/routes.test.js
+++ b/test/integration/routes.test.js
@@ -51,7 +51,7 @@ describe('routes', function () {
     nock.cleanAll()
   })
 
-  describe.only('health check', function () {
+  describe('health check', function () {
     let app, statusHandler
 
     before(async function () {


### PR DESCRIPTION
The substrate promise `isReadyOrError` when resolved is never re-evaluated. Therefore the previous implmentation didn't work. This change instead uses the `isConnected` property which is maintained and updated by the library.

~Draft pending some attempts to integration test this~

My original plan for testing this was to use `nock` to intercept the connection and prevent it talking to substrate. Unfortunately nock [doesn't work with websockets](https://github.com/nock/nock/issues/129). Instead I mock out the behaviour of the API which works