### PR TITLE
Add configration of EXTERNAL_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ The following environment variables are used by `dscp-api` and can be configured
 | variable                        | required |        default         | description                                                                                  |
 | :------------------------------ | :------: | :--------------------: | :------------------------------------------------------------------------------------------- |
 | PORT                            |    N     |         `3001`         | The port for the API to listen on                                                            |
+| EXTERNAL_URL                    |    N     |                        | The url from which the OpenAPI service is accessible. If not provided the value will default to `http://localhost:${PORT}/${API_MAJOR_VERSION}` |
 | API_HOST                        |    Y     |           -            | The hostname of the `dscp-node` the API should connect to                                    |
 | API_PORT                        |    N     |         `9944`         | The port of the `dscp-node` the API should connect to                                        |
 | LOG_LEVEL                       |    N     |         `info`         | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`]         |

--- a/app/api-v3/api-doc.js
+++ b/app/api-v3/api-doc.js
@@ -1,4 +1,4 @@
-const { PORT, API_VERSION, API_MAJOR_VERSION } = require('../env')
+const { PORT, API_VERSION, API_MAJOR_VERSION, EXTERNAL_URL } = require('../env')
 
 const apiDoc = {
   openapi: '3.0.3',
@@ -8,7 +8,7 @@ const apiDoc = {
   },
   servers: [
     {
-      url: `http://localhost:${PORT}/${API_MAJOR_VERSION}`,
+      url: EXTERNAL_URL || `http://localhost:${PORT}/${API_MAJOR_VERSION}`,
     },
   ],
   components: {

--- a/app/env.js
+++ b/app/env.js
@@ -41,6 +41,7 @@ const vars = envalid.cleanEnv(process.env, {
   SUBSTRATE_STATUS_TIMEOUT_MS: envalid.num({ default: 2 * 1000 }),
   IPFS_STATUS_POLL_PERIOD_MS: envalid.num({ default: 10 * 1000 }),
   IPFS_STATUS_TIMEOUT_MS: envalid.num({ default: 2 * 1000 }),
+  EXTERNAL_URL: envalid.str({ default: '' }),
 })
 
 module.exports = {

--- a/app/server.js
+++ b/app/server.js
@@ -7,7 +7,7 @@ const multer = require('multer')
 const path = require('path')
 const bodyParser = require('body-parser')
 const compression = require('compression')
-const { PORT, API_VERSION, API_MAJOR_VERSION, AUTH_TYPE } = require('./env')
+const { PORT, API_VERSION, API_MAJOR_VERSION, AUTH_TYPE, EXTERNAL_URL } = require('./env')
 const logger = require('./logger')
 const apiDoc = require('./api-v3/api-doc')
 const apiService = require('./api-v3/services/apiService')
@@ -88,7 +88,7 @@ async function createHttpServer() {
     swaggerOptions: {
       urls: [
         {
-          url: `../api-docs`,
+          url: EXTERNAL_URL ? `${EXTERNAL_URL}/api-docs` : `../api-docs`,
           name: 'ApiService',
         },
       ],

--- a/app/server.js
+++ b/app/server.js
@@ -88,7 +88,7 @@ async function createHttpServer() {
     swaggerOptions: {
       urls: [
         {
-          url: `http://localhost:${PORT}/${API_MAJOR_VERSION}/api-docs`,
+          url: `../api-docs`,
           name: 'ApiService',
         },
       ],

--- a/helm/dscp-api/Chart.yaml
+++ b/helm/dscp-api/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: dscp-api
-appVersion: '4.6.2'
+appVersion: '4.6.3'
 description: A Helm chart for dscp-api
-version: '4.6.2'
+version: '4.6.3'
 type: application
 dependencies:
   - name: dscp-node

--- a/helm/dscp-api/templates/configmap.yaml
+++ b/helm/dscp-api/templates/configmap.yaml
@@ -6,6 +6,9 @@ metadata:
     {{- include "dscp-api.labels" . | nindent 4 }}
 data:
   port: {{ .Values.config.port | quote }}
+  {{- if .Values.config.externalUrl }}
+  externalUrl: {{ .Values.config.externalUrl }}
+  {{- end }}
   logLevel: {{ .Values.config.logLevel }}
   nodeHost: {{ include "dscp-api.node-host" . }}
   {{- if .Values.config.externalIpfsHost }}

--- a/helm/dscp-api/templates/deployment.yaml
+++ b/helm/dscp-api/templates/deployment.yaml
@@ -83,6 +83,13 @@ spec:
                 secretKeyRef:
                   name: {{ include "dscp-api.fullname" . }}-secret
                   key: accountKey
+            {{- if .Values.config.externalUrl }}
+            - name: EXTERNAL_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "dscp-api.fullname" . }}-config
+                  key: externalUrl
+            {{- end }}
             {{- if eq .Values.config.auth.type "JWT" }}
             - name: AUTH_JWKS_URI
               valueFrom:

--- a/helm/dscp-api/values.yaml
+++ b/helm/dscp-api/values.yaml
@@ -1,7 +1,7 @@
 # fullNameOverride:
 config:
   port: 80
-  # externalNodeHost: "" # This overrides dscpNode.enabled when setting the API_HOST envar
+  # externalUrl: "http://localhost:3000/v3" # Overrides the server url in the openapi spec
   logLevel: info
   accountKey: //Alice
   # externalIpfsHost: "" # This overrides dscpIpfs.enabled when setting the IPFS_HOST envar
@@ -37,7 +37,7 @@ service:
 image:
   repository: digicatapult/dscp-api
   pullPolicy: IfNotPresent
-  tag: 'v4.6.2'
+  tag: 'v4.6.3'
 
 dscpNode:
   enabled: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dscp-api",
-  "version": "4.6.2",
+  "version": "4.6.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dscp-api",
-      "version": "4.6.2",
+      "version": "4.6.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/dscp-node": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dscp-api",
-  "version": "4.6.2",
+  "version": "4.6.3",
   "description": "DSCP API",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adds the env `EXTERNAL_URL` which if provided will override the `url` field in the published openapi spec. 
