### PR TITLE
Rename DSCP to Veritable

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behaviour may be reported by contacting the project team at [opensource@digicatapult.org.uk](mailto:opensource@digicatapult.org.uk?subject=DSCP). All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team's obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be reported by contacting the project team at [opensource@digicatapult.org.uk](mailto:opensource@digicatapult.org.uk?subject=Veritable). All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team's obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
-# Contributing to dscp-api
+# Contributing to veritable-api
 
 Firstly, we would like to thank you for taking the time to contribute!
 
-The following is a set of guidelines for contributing to DSCP and its packages, which are hosted on the [digicatapult](https://github.com/digicatapult) organisation on GitHub. These are mostly guidelines, not rules. Use your best judgement, and feel free to propose changes to this document in a pull request.
+The following is a set of guidelines for contributing to Veritable and its packages, which are hosted on the [digicatapult](https://github.com/digicatapult) organisation on GitHub. These are mostly guidelines, not rules. Use your best judgement, and feel free to propose changes to this document in a pull request.
 
 #### Table Of Contents
 
@@ -34,7 +34,7 @@ We don't have any frequently asked questions yet.
 
 ### Reporting Bugs
 
-This section guides you through submitting a bug report for dscp-api. Following these guidelines helps maintainers and the community understand your report :pencil:, reproduce the behaviour :computer: :computer:, and find related reports :mag_right:.
+This section guides you through submitting a bug report for veritable-api. Following these guidelines helps maintainers and the community understand your report :pencil:, reproduce the behaviour :computer: :computer:, and find related reports :mag_right:.
 
 Before creating bug reports, please check [this list](#before-submitting-a-bug-report) as you might find out that you don't need to create one. When you are creating a bug report, please [include as many details as possible](#how-do-i-submit-a-good-bug-report). Fill out [the required template](https://github.com/digicatapult/dscp-api/blob/main/.github/ISSUE_TEMPLATE/bug_report.md), the information it asks for helps us resolve issues faster.
 
@@ -56,24 +56,24 @@ Explain the problem and include additional details to help maintainers reproduce
 - **Describe the behaviour you observed after following the steps** and point out what exactly is the problem with that behaviour.
 - **Explain which behaviour you expected to see instead and why.**
 - **Include screenshots and animated GIFs** which show you following the described steps and clearly demonstrate the problem. If you use the keyboard while following the steps, \*\*record the GIF with the [this tool](https://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/Xaviju/byzanzUI) on Linux.
-- **If you're reporting that dscp-api crashed**, include a crash report with a stack trace from the operating system. On macOS, the crash report will be available in `Console.app` under "Diagnostic and usage information" > "User diagnostic reports". Include the crash report in the issue in a [code block](https://help.github.com/articles/markdown-basics/#multiple-lines), a [file attachment](https://help.github.com/articles/file-attachments-on-issues-and-pull-requests/), or put it in a [gist](https://gist.github.com/) and provide link to that gist.
+- **If you're reporting that veritable-api crashed**, include a crash report with a stack trace from the operating system. On macOS, the crash report will be available in `Console.app` under "Diagnostic and usage information" > "User diagnostic reports". Include the crash report in the issue in a [code block](https://help.github.com/articles/markdown-basics/#multiple-lines), a [file attachment](https://help.github.com/articles/file-attachments-on-issues-and-pull-requests/), or put it in a [gist](https://gist.github.com/) and provide link to that gist.
 - **If the problem wasn't triggered by a specific action**, describe what you were doing before the problem happened and share more information using the guidelines below.
 
 Provide more context by answering these questions:
 
-- **Did the problem start happening recently** (e.g. after updating to a new version of dscp-api) or was this always a problem?
-- If the problem started happening recently, **can you reproduce the problem in an older version of dscp-api?** What's the most recent version in which the problem doesn't happen? You can checkout older versions of dscp-api from [the releases page](https://github.com/digicatapult/dscp-api/releases).
+- **Did the problem start happening recently** (e.g. after updating to a new version of veritable-api) or was this always a problem?
+- If the problem started happening recently, **can you reproduce the problem in an older version of veritable-api?** What's the most recent version in which the problem doesn't happen? You can checkout older versions of veritable-api from [the releases page](https://github.com/digicatapult/dscp-api/releases).
 - **Can you reliably reproduce the issue?** If not, provide details about how often the problem happens and under which conditions it normally happens.
 
 Include details about your configuration and environment:
 
-- **Which version of dscp-api are you using?** You can get the exact version from the version attribute within package.json.
-- **What's the name and version of the OS you've deployed dscp-api to**?
-- **Are you running dscp-api in a virtual machine?** If so, which VM software are you using and which operating systems and versions are used for the host and the guest?
+- **Which version of veritable-api are you using?** You can get the exact version from the version attribute within package.json.
+- **What's the name and version of the OS you've deployed veritable-api to**?
+- **Are you running veritable-api in a virtual machine?** If so, which VM software are you using and which operating systems and versions are used for the host and the guest?
 
 ### Suggesting Enhancements
 
-This section guides you through submitting an enhancement suggestion for dscp-api, including completely new features and minor improvements to existing functionality. Following these guidelines helps maintainers and the community understand your suggestion :pencil: and find related suggestions :mag_right:.
+This section guides you through submitting an enhancement suggestion for veritable-api, including completely new features and minor improvements to existing functionality. Following these guidelines helps maintainers and the community understand your suggestion :pencil: and find related suggestions :mag_right:.
 
 Before creating enhancement suggestions, please check [this list](#before-submitting-an-enhancement-suggestion) as you might find out that you don't need to create one. When you are creating an enhancement suggestion, please [include as many details as possible](#how-do-i-submit-a-good-enhancement-suggestion). Fill in [the template](https://github.com/digicatapult/dscp-api/blob/main/.github/ISSUE_TEMPLATE/feature_request.md), including the steps that you imagine you would take if the feature you're requesting existed.
 
@@ -89,19 +89,19 @@ Enhancement suggestions are tracked as [GitHub issues](https://guides.github.com
 - **Provide a step-by-step description of the suggested enhancement** in as many details as possible.
 - **Provide specific examples to demonstrate the steps**. Include copy/pasteable snippets which you use in those examples, as [Markdown code blocks](https://help.github.com/articles/markdown-basics/#multiple-lines).
 - **Describe the current behaviour** and **explain which behaviour you expected to see instead** and why.
-- **Include screenshots and animated GIFs** which help you demonstrate the steps or point out the part of dscp-api which the suggestion is related to. You can use [this tool](https://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/GNOME/byzanz) on Linux.
-- **Explain why this enhancement would be useful** to most dscp-api users.
+- **Include screenshots and animated GIFs** which help you demonstrate the steps or point out the part of veritable-api which the suggestion is related to. You can use [this tool](https://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/GNOME/byzanz) on Linux.
+- **Explain why this enhancement would be useful** to most veritable-api users.
 - **List some other text editors or applications where this enhancement exists.**
-- **Specify which version of dscp-api you're using.** You can get the exact version from the version attribute within package.json.
-- **What's the name and version of the OS you've deployed dscp-api to**?
+- **Specify which version of veritable-api you're using.** You can get the exact version from the version attribute within package.json.
+- **What's the name and version of the OS you've deployed veritable-api to**?
 
 ### Pull Requests
 
 The process described here has several goals:
 
-- Maintain dscp-api's quality
+- Maintain veritable-api's quality
 - Fix problems that are important to users
-- Enable a sustainable system for dscp-api's maintainers to review contributions
+- Enable a sustainable system for veritable-api's maintainers to review contributions
 
 Please follow these steps to have your contribution considered by the maintainers:
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# DSCP API
+# Veritable API
 
 ## Description
 
-A `Node.js` API to support communication to the [Substrate-based](https://www.substrate.io/) [`dscp-node`](https://github.com/digicatapult/dscp-node) (via [`polkadot-js/api`](https://www.npmjs.com/package/@polkadot/api)) and an [`IPFS`](https://ipfs.io/) node.
+A `Node.js` API to support communication to the [Substrate-based](https://www.substrate.io/) [`veritable-node`](https://github.com/digicatapult/dscp-node) (via [`polkadot-js/api`](https://www.npmjs.com/package/@polkadot/api)) and an [`IPFS`](https://ipfs.io/) node.
 
 ## Getting started
 
@@ -12,12 +12,12 @@ First, ensure you're running the correct [version](.node-version) of `npm`, then
 npm install
 ```
 
-The API requires instances of [`dscp-node`](https://github.com/digicatapult/dscp-node) and [`IPFS`](https://ipfs.io/).
+The API requires instances of [`veritable-node`](https://github.com/digicatapult/dscp-node) and [`IPFS`](https://ipfs.io/).
 To bring them up locally:
 
-### `dscp-node`
+### `veritable-node`
 
-Clone [dscp-node](https://github.com/digicatapult/dscp-node) and follow the README to setup and build a local node. Then run the following in its root directory:
+Clone [veritable-node](https://github.com/digicatapult/dscp-node) and follow the README to setup and build a local node. Then run the following in its root directory:
 
 ```
 ./target/release/dscp-node --dev
@@ -46,11 +46,11 @@ npm run test:integration
 
 ## Authentication
 
-`dscp-api` uses an [Auth0](https://auth0.com/) Machine to Machine API to issue a JSON Web Token for authentication on its endpoints. You will need to create your own Auth0 API, which can be done for free, and set the appropriate [environment variables](#configuration) (those prefixed with `AUTH`). Follow the start of this [tutorial](https://auth0.com/docs/quickstart/backend/nodejs#configure-auth0-apis) to create an API. Go [here](app/routes/auth.js) and [here](app/auth.js) to see where the environment variables are used.
+`veritable-api` uses an [Auth0](https://auth0.com/) Machine to Machine API to issue a JSON Web Token for authentication on its endpoints. You will need to create your own Auth0 API, which can be done for free, and set the appropriate [environment variables](#configuration) (those prefixed with `AUTH`). Follow the start of this [tutorial](https://auth0.com/docs/quickstart/backend/nodejs#configure-auth0-apis) to create an API. Go [here](app/routes/auth.js) and [here](app/auth.js) to see where the environment variables are used.
 
 ## Configuration
 
-The following environment variables are used by `dscp-api` and can be configured. Entries marked as `required` are needed when running `dscp-api` in production mode.
+The following environment variables are used by `veritable-api` and can be configured. Entries marked as `required` are needed when running `veritable-api` in production mode.
 
 | variable                        | required |        default         | description                                                                                  |
 | :------------------------------ | :------: | :--------------------: | :------------------------------------------------------------------------------------------- |
@@ -97,7 +97,7 @@ npm start
 
 ### Authenticated endpoints
 
-If `AUTH_TYPE` env is set to `JWT`, the rest of the endpoints in `dscp-api` require authentication in the form of a header `'Authorization: Bearer YOUR_ACCESS_TOKEN'`:
+If `AUTH_TYPE` env is set to `JWT`, the rest of the endpoints in `veritable-api` require authentication in the form of a header `'Authorization: Bearer YOUR_ACCESS_TOKEN'`:
 
 1. [GET /item/:id](#get-/item/:id)
 2. [GET /item/:id/metadata/:metadataKey](#get-/item/:id/metadata/:metadataKey)

--- a/helm/dscp-api/Chart.yaml
+++ b/helm/dscp-api/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: dscp-api
-appVersion: '4.8.0'
+appVersion: '4.8.1'
 description: A Helm chart for dscp-api
-version: '4.8.0'
+version: '4.8.1'
 type: application
 dependencies:
   - name: dscp-node

--- a/helm/dscp-api/values.yaml
+++ b/helm/dscp-api/values.yaml
@@ -38,7 +38,7 @@ service:
 image:
   repository: digicatapult/dscp-api
   pullPolicy: IfNotPresent
-  tag: 'v4.8.0'
+  tag: 'v4.8.1'
 
 dscpNode:
   enabled: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dscp-api",
-  "version": "4.8.0",
+  "version": "4.8.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dscp-api",
-      "version": "4.8.0",
+      "version": "4.8.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/dscp-node": "^4.4.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dscp-api",
-  "version": "4.8.0",
+  "version": "4.8.1",
   "description": "DSCP API",
   "type": "module",
   "repository": {


### PR DESCRIPTION
This renames `DSCP` to `Veritable` where appropriate in markdown files.
