### PR TITLE
Replace dscp-node package with @polkadot/api

### DIFF
--- a/app/util/substrateApi.js
+++ b/app/util/substrateApi.js
@@ -8,7 +8,7 @@ const { API_HOST, API_PORT } = env
 const provider = new WsProvider(`ws://${API_HOST}:${API_PORT}`)
 const api = new ApiPromise({ provider })
 
-api.isReadyOrError.catch(() => {})
+api.isReadyOrError.catch(() => {}) // prevent unhandled promise rejection errors
 
 api.on('disconnected', () => {
   logger.warn(`Disconnected from substrate node at ${API_HOST}:${API_PORT}`)

--- a/app/util/substrateApi.js
+++ b/app/util/substrateApi.js
@@ -1,16 +1,14 @@
-import { buildApi } from '@digicatapult/dscp-node'
+import { ApiPromise, WsProvider, Keyring } from '@polkadot/api'
 
 import env from '../env.js'
 import logger from '../logger.js'
 
 const { API_HOST, API_PORT } = env
 
-const { api, keyring: kr } = buildApi({
-  options: {
-    apiHost: API_HOST,
-    apiPort: API_PORT,
-  },
-})
+const provider = new WsProvider(`ws://${API_HOST}:${API_PORT}`)
+const api = new ApiPromise({ provider })
+
+api.isReadyOrError.catch(() => {})
 
 api.on('disconnected', () => {
   logger.warn(`Disconnected from substrate node at ${API_HOST}:${API_PORT}`)
@@ -25,4 +23,4 @@ api.on('error', (err) => {
 })
 
 export const substrateApi = api
-export const keyring = kr
+export const keyring = new Keyring({ type: 'sr25519' })

--- a/helm/dscp-api/Chart.yaml
+++ b/helm/dscp-api/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: dscp-api
-appVersion: '4.8.1'
+appVersion: '4.8.2'
 description: A Helm chart for dscp-api
-version: '4.8.1'
+version: '4.8.2'
 type: application
 dependencies:
   - name: dscp-node

--- a/helm/dscp-api/values.yaml
+++ b/helm/dscp-api/values.yaml
@@ -38,7 +38,7 @@ service:
 image:
   repository: digicatapult/dscp-api
   pullPolicy: IfNotPresent
-  tag: 'v4.8.1'
+  tag: 'v4.8.2'
 
 dscpNode:
   enabled: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.8.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@digicatapult/dscp-node": "^4.4.6",
+        "@polkadot/api": "^9.9.1",
         "base-x": "^4.0.0",
         "body-parser": "^1.20.1",
         "compression": "^1.7.4",
@@ -422,18 +422,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@digicatapult/dscp-node": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@digicatapult/dscp-node/-/dscp-node-4.4.6.tgz",
-      "integrity": "sha512-h8R2h9mfW3YrhwZ3P3KPKV+uGOlj6kIMBXv7vQmg9cA+0yCBUHHUNwUQp7jpudV7cpTFzV6QNSw9k21IrTGi/w==",
-      "dependencies": {
-        "@polkadot/api": "^8.11.3"
-      },
-      "engines": {
-        "node": "16.x.x",
-        "npm": "8.x.x"
-      }
-    },
     "node_modules/@eslint/eslintrc": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
@@ -752,108 +740,108 @@
       }
     },
     "node_modules/@polkadot/api": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-8.14.1.tgz",
-      "integrity": "sha512-jg26eIKFYqVfDBTAopHL3aDaNw9j6TdUkXuvYJOnynpecU4xwbTVKcOtSOjJ2eRX4MgMQ4zlyMHJx3iKw0uUTA==",
+      "version": "9.9.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-9.9.1.tgz",
+      "integrity": "sha512-3ltj6BbqEV9SCUlJIEmXWBmmQlZCvVPaj0N+99J9L2yiQ1E0KJsAizh10RxEjCvgYb2iWaE4ItPfhN0GxFJm7Q==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/api-augment": "8.14.1",
-        "@polkadot/api-base": "8.14.1",
-        "@polkadot/api-derive": "8.14.1",
-        "@polkadot/keyring": "^10.1.1",
-        "@polkadot/rpc-augment": "8.14.1",
-        "@polkadot/rpc-core": "8.14.1",
-        "@polkadot/rpc-provider": "8.14.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-augment": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/types-create": "8.14.1",
-        "@polkadot/types-known": "8.14.1",
-        "@polkadot/util": "^10.1.1",
-        "@polkadot/util-crypto": "^10.1.1",
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/api-augment": "9.9.1",
+        "@polkadot/api-base": "9.9.1",
+        "@polkadot/api-derive": "9.9.1",
+        "@polkadot/keyring": "^10.1.13",
+        "@polkadot/rpc-augment": "9.9.1",
+        "@polkadot/rpc-core": "9.9.1",
+        "@polkadot/rpc-provider": "9.9.1",
+        "@polkadot/types": "9.9.1",
+        "@polkadot/types-augment": "9.9.1",
+        "@polkadot/types-codec": "9.9.1",
+        "@polkadot/types-create": "9.9.1",
+        "@polkadot/types-known": "9.9.1",
+        "@polkadot/util": "^10.1.13",
+        "@polkadot/util-crypto": "^10.1.13",
         "eventemitter3": "^4.0.7",
-        "rxjs": "^7.5.6"
+        "rxjs": "^7.5.7"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/api-augment": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-8.14.1.tgz",
-      "integrity": "sha512-65GMlgVnZd08Ifh8uAj+p/+MlXxvsAfBcCHjQhOmbCE0dki+rzTPUR31LsWyDKtuw+nUBj0iZN4PelO+wU4r0g==",
+      "version": "9.9.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-9.9.1.tgz",
+      "integrity": "sha512-0HS6Kit9ZiO2iQU/aS/jpOjXl9rFcwW6FdUs1eSXvWjvAFpoxwCMG8bv8wVjNZcCUuA2w5U0+2B+Xa612QEQQg==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/api-base": "8.14.1",
-        "@polkadot/rpc-augment": "8.14.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-augment": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/util": "^10.1.1"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/api-base": "9.9.1",
+        "@polkadot/rpc-augment": "9.9.1",
+        "@polkadot/types": "9.9.1",
+        "@polkadot/types-augment": "9.9.1",
+        "@polkadot/types-codec": "9.9.1",
+        "@polkadot/util": "^10.1.13"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/api-base": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-8.14.1.tgz",
-      "integrity": "sha512-EXFhNXIfpirf18IsqcG2pGQW1/Xn+bfjqVYQMMJ4ZONtYH4baZZlXk7SoXCCHonN2x1ixs4DOcRx5oVxjabdIQ==",
+      "version": "9.9.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-9.9.1.tgz",
+      "integrity": "sha512-uJDLi+nHQ08QZ+p1ldzwMeNjCyIkpR1DOzvKV3M3bLepglF8r7V/7W5dXk+qlClMqgB92RgKwo4R6EPRgr5BcA==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/rpc-core": "8.14.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/util": "^10.1.1",
-        "rxjs": "^7.5.6"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/rpc-core": "9.9.1",
+        "@polkadot/types": "9.9.1",
+        "@polkadot/util": "^10.1.13",
+        "rxjs": "^7.5.7"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/api-derive": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-8.14.1.tgz",
-      "integrity": "sha512-eWG1MrQhHMUjt9gDHN9/9/ZMATu1MolqcalPFhNoGtdON3+I0J3ntjQ4y5X7+p2OGwQplpYRKqbK4k7tKzu8tA==",
+      "version": "9.9.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-9.9.1.tgz",
+      "integrity": "sha512-cCCbnhXfCo9Mj4DCM0TVoDOEe5yleOLdqoICU9T4PMv5R51D+iMmw97+MYCgyjRdm7wIW05LlW32iUVrgDiSJw==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/api": "8.14.1",
-        "@polkadot/api-augment": "8.14.1",
-        "@polkadot/api-base": "8.14.1",
-        "@polkadot/rpc-core": "8.14.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/util": "^10.1.1",
-        "@polkadot/util-crypto": "^10.1.1",
-        "rxjs": "^7.5.6"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/api": "9.9.1",
+        "@polkadot/api-augment": "9.9.1",
+        "@polkadot/api-base": "9.9.1",
+        "@polkadot/rpc-core": "9.9.1",
+        "@polkadot/types": "9.9.1",
+        "@polkadot/types-codec": "9.9.1",
+        "@polkadot/util": "^10.1.13",
+        "@polkadot/util-crypto": "^10.1.13",
+        "rxjs": "^7.5.7"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/keyring": {
-      "version": "10.1.12",
-      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-10.1.12.tgz",
-      "integrity": "sha512-zwTWOa+Glg0NT+EoOOjg9U6dotGPxDpr8xdpkg9EXcyKMa5Pw7alrUg+V3tC+5Ttu7dsZRCJKW8jEshCekulWA==",
+      "version": "10.1.13",
+      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-10.1.13.tgz",
+      "integrity": "sha512-O5/sM1cfn/ueT7C6sxqZI9Z18RLOpPovdfZzBlcRAyfs/8uR+UA20r2lGCQdQIzlOeF0XPebIO0lwW+6wPtvtg==",
       "dependencies": {
         "@babel/runtime": "^7.20.1",
-        "@polkadot/util": "10.1.12",
-        "@polkadot/util-crypto": "10.1.12"
+        "@polkadot/util": "10.1.13",
+        "@polkadot/util-crypto": "10.1.13"
       },
       "engines": {
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "@polkadot/util": "10.1.12",
-        "@polkadot/util-crypto": "10.1.12"
+        "@polkadot/util": "10.1.13",
+        "@polkadot/util-crypto": "10.1.13"
       }
     },
     "node_modules/@polkadot/networks": {
-      "version": "10.1.12",
-      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-10.1.12.tgz",
-      "integrity": "sha512-asobCUdRSsnSIZKoqFsaPPtUPvbaNPh3r1XOvNqgrE65wsoNx15AiuqAigW2RKOoqVrUW7zthRJ5Xmk0MKS9GA==",
+      "version": "10.1.13",
+      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-10.1.13.tgz",
+      "integrity": "sha512-EvR0weOZlTS9AzQd8/s7WJrLCfAdaP3fKPSoaJkir1fUrpmhagMZaIm+kHmKO3lqEaqV+EAZm3Ee43bZN0na7A==",
       "dependencies": {
         "@babel/runtime": "^7.20.1",
-        "@polkadot/util": "10.1.12",
+        "@polkadot/util": "10.1.13",
         "@substrate/ss58-registry": "^1.34.0"
       },
       "engines": {
@@ -861,51 +849,51 @@
       }
     },
     "node_modules/@polkadot/rpc-augment": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-8.14.1.tgz",
-      "integrity": "sha512-0dIsNVIMeCp0kV7+Obz0Odt6K32Ka2ygwhiV5jhhJthy8GJBPo94mKDed5gzln3Dgl2LEdJJt1h/pgCx4a2i4A==",
+      "version": "9.9.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-9.9.1.tgz",
+      "integrity": "sha512-t3gTendxM9KD9Sg+hT7Wn72Xdusl25EsXcdOjFqQWUtFL8xjYcFngrTTifG90e+ciFIk1DWps2+zc6lbDwBfeA==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/rpc-core": "8.14.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/util": "^10.1.1"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/rpc-core": "9.9.1",
+        "@polkadot/types": "9.9.1",
+        "@polkadot/types-codec": "9.9.1",
+        "@polkadot/util": "^10.1.13"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/rpc-core": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-8.14.1.tgz",
-      "integrity": "sha512-deQ8Ob59ao/1fZQdaVtFjYR/HCBdxSYvQGt7/alBu1Uig9Sahx9oKcMkU5rWY36XqGZYos4zLay98W2hDlf+6Q==",
+      "version": "9.9.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-9.9.1.tgz",
+      "integrity": "sha512-ij1OxDfbPpdZ9+aN8oicZrysIfUjC7INBhDwwoZ4R/4jhqJvIV1fisgj6XOdHGlZGl+vQBnObOw0nEOU7apdQg==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/rpc-augment": "8.14.1",
-        "@polkadot/rpc-provider": "8.14.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/util": "^10.1.1",
-        "rxjs": "^7.5.6"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/rpc-augment": "9.9.1",
+        "@polkadot/rpc-provider": "9.9.1",
+        "@polkadot/types": "9.9.1",
+        "@polkadot/util": "^10.1.13",
+        "rxjs": "^7.5.7"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/rpc-provider": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-8.14.1.tgz",
-      "integrity": "sha512-pAUSHZiSWLhBSYf4LmLc8iCaeqTu7Ajn8AzyqxvZDHGnIrzV5M7eTjpNDP84qno6jWRHKQ/IILr62hausEmS5w==",
+      "version": "9.9.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-9.9.1.tgz",
+      "integrity": "sha512-YyIwYDAgeEAAjvsH/v5v6sFkhkoaER98rPIcfP+81sGcxpjBCArg4feDtzTPQMsnUcbj3708ppJicu6ECc1xFg==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/keyring": "^10.1.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-support": "8.14.1",
-        "@polkadot/util": "^10.1.1",
-        "@polkadot/util-crypto": "^10.1.1",
-        "@polkadot/x-fetch": "^10.1.1",
-        "@polkadot/x-global": "^10.1.1",
-        "@polkadot/x-ws": "^10.1.1",
-        "@substrate/connect": "0.7.9",
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/keyring": "^10.1.13",
+        "@polkadot/types": "9.9.1",
+        "@polkadot/types-support": "9.9.1",
+        "@polkadot/util": "^10.1.13",
+        "@polkadot/util-crypto": "^10.1.13",
+        "@polkadot/x-fetch": "^10.1.13",
+        "@polkadot/x-global": "^10.1.13",
+        "@polkadot/x-ws": "^10.1.13",
+        "@substrate/connect": "0.7.17",
         "eventemitter3": "^4.0.7",
         "mock-socket": "^9.1.5",
         "nock": "^13.2.9"
@@ -915,101 +903,101 @@
       }
     },
     "node_modules/@polkadot/types": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-8.14.1.tgz",
-      "integrity": "sha512-Xza16ejKrSd4XhTOlbfISyxZ2sRmbMAZk5pX7VEMHVZHqV98o+bJ2f9Kk7F8YJijkHHGosCLDestP9R5nLoOoA==",
+      "version": "9.9.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-9.9.1.tgz",
+      "integrity": "sha512-WK0CPj0LZhb5ZSfhMvT5ZZv0nnqz9wQdRSehjqeuq7DD2TgTIPZL22zP4UjJPAJEyTtwyfcRn6+ZhL2JS5w0Jg==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/keyring": "^10.1.1",
-        "@polkadot/types-augment": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/types-create": "8.14.1",
-        "@polkadot/util": "^10.1.1",
-        "@polkadot/util-crypto": "^10.1.1",
-        "rxjs": "^7.5.6"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/keyring": "^10.1.13",
+        "@polkadot/types-augment": "9.9.1",
+        "@polkadot/types-codec": "9.9.1",
+        "@polkadot/types-create": "9.9.1",
+        "@polkadot/util": "^10.1.13",
+        "@polkadot/util-crypto": "^10.1.13",
+        "rxjs": "^7.5.7"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/types-augment": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-8.14.1.tgz",
-      "integrity": "sha512-Xa4TUFqyZT+IJ6pBSwDjWcF42u/E34OyC+gbs5Z2vWQ4EzSDkq4xNoUKjJlEEgTemsD9lhPOIc4jvqTCefwxEw==",
+      "version": "9.9.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-9.9.1.tgz",
+      "integrity": "sha512-h4DhtVPbe7/6Mdwickqih3ltvEV9y08a8LVvjxVVaGw1gRcoQpcMLkvsyWh5caYBPCKuJvXV40p4PnvO/HtW2A==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/util": "^10.1.1"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/types": "9.9.1",
+        "@polkadot/types-codec": "9.9.1",
+        "@polkadot/util": "^10.1.13"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/types-codec": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-8.14.1.tgz",
-      "integrity": "sha512-y6YDN4HwvEgSWlgrEV04QBBxDxES1cTuUQFzZJzOTuZCWpA371Mdj3M9wYxGXMnj0wa+rCQGECHPZZaNxBMiKg==",
+      "version": "9.9.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-9.9.1.tgz",
+      "integrity": "sha512-vBzInneVp2ClDD/bmrf9HUp9La0udBJnhvyqwdLA2IKQBjIYOxVtuC62D4dg1Svp34NH4+b/nAtWlOvflSjOQQ==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/util": "^10.1.1",
-        "@polkadot/x-bigint": "^10.1.1"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/util": "^10.1.13",
+        "@polkadot/x-bigint": "^10.1.13"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/types-create": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-8.14.1.tgz",
-      "integrity": "sha512-fb9yyblj5AYAPzeCIq0kYSfzDxRDi/0ud9gN2UzB3H7M/O4n2mPC1vD4UOLF+B7l9QzCrt4e+k+/riGp7GfvyA==",
+      "version": "9.9.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-9.9.1.tgz",
+      "integrity": "sha512-fzHTdWdXPbJxAYNP2nFzM9B1Nom7wiIFalltIj3jLQYF8uCgPuMF4/nLDi5uEg5YpCBCTagqyoVUuEd4riDS/Q==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/util": "^10.1.1"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/types-codec": "9.9.1",
+        "@polkadot/util": "^10.1.13"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/types-known": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-8.14.1.tgz",
-      "integrity": "sha512-GP7gRo9nmitykkrRnoLF61Qm19UFdTwMsOnJkdm7AOeWDmZGxutacgO6k1tBsHr38hsiCCGsB/JiseUgywvGIw==",
+      "version": "9.9.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-9.9.1.tgz",
+      "integrity": "sha512-kD51etsC0Oh5RnBTVabxmIqXe03XRYBDAaaC6yj2MGiPsyuy3X6g26xPZy9pSYcjkkWIF81CtPcLaJE5YrG0/A==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/networks": "^10.1.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/types-create": "8.14.1",
-        "@polkadot/util": "^10.1.1"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/networks": "^10.1.13",
+        "@polkadot/types": "9.9.1",
+        "@polkadot/types-codec": "9.9.1",
+        "@polkadot/types-create": "9.9.1",
+        "@polkadot/util": "^10.1.13"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/types-support": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-8.14.1.tgz",
-      "integrity": "sha512-XqR4qq6pCZyNBuFVod8nFSNUmLssrjoU9bOIn4Ua2cqNlI9xsuKaI1X5ySEn/oWOtKQ2L5hbCm9vkXrEtXBl1w==",
+      "version": "9.9.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-9.9.1.tgz",
+      "integrity": "sha512-PGu80mMvyr+rD6pi8Z/r9l650cadpW4X+pWt4tJnKYAbtiaE9mQJGFwq+HgY3vExzRDhaXNOUDg9d1ry5XUvJQ==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/util": "^10.1.1"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/util": "^10.1.13"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/util": {
-      "version": "10.1.12",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.1.12.tgz",
-      "integrity": "sha512-bOz1WqDFzIgkTpT6oRhAdXKqETr2GffZdRlYqyOvP1ATAEa48/sRgzIvg7WTiI68D8By3fJmKuA+ggX3YrNF/w==",
+      "version": "10.1.13",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.1.13.tgz",
+      "integrity": "sha512-wedd6NKIA1gKUm21SFwsq8UzQrMAzc2fBjrfD07LIXEJ2S/q5IKF57NjGMzf6fdNFt0376VNLUGD4MbxSc9/HA==",
       "dependencies": {
         "@babel/runtime": "^7.20.1",
-        "@polkadot/x-bigint": "10.1.12",
-        "@polkadot/x-global": "10.1.12",
-        "@polkadot/x-textdecoder": "10.1.12",
-        "@polkadot/x-textencoder": "10.1.12",
+        "@polkadot/x-bigint": "10.1.13",
+        "@polkadot/x-global": "10.1.13",
+        "@polkadot/x-textdecoder": "10.1.13",
+        "@polkadot/x-textencoder": "10.1.13",
         "@types/bn.js": "^5.1.1",
         "bn.js": "^5.2.1"
       },
@@ -1018,18 +1006,18 @@
       }
     },
     "node_modules/@polkadot/util-crypto": {
-      "version": "10.1.12",
-      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-10.1.12.tgz",
-      "integrity": "sha512-X/IxeMMYMVWhByU2be5bzPFy8acPTa2oLcvzSKLjhxqtCEIqprs/fshhfT3qVTa/lAN+WeNE8oTPCPLKVpQE4w==",
+      "version": "10.1.13",
+      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-10.1.13.tgz",
+      "integrity": "sha512-LYHsJM8hzsvehO2T1S5vMFX7k2gCt/QnG3NzSGo+97OauitrICN8V7py4o5TOewUzMeihNMVKjRkj/cC4e+i4Q==",
       "dependencies": {
         "@babel/runtime": "^7.20.1",
         "@noble/hashes": "1.1.3",
         "@noble/secp256k1": "1.7.0",
-        "@polkadot/networks": "10.1.12",
-        "@polkadot/util": "10.1.12",
+        "@polkadot/networks": "10.1.13",
+        "@polkadot/util": "10.1.13",
         "@polkadot/wasm-crypto": "^6.3.1",
-        "@polkadot/x-bigint": "10.1.12",
-        "@polkadot/x-randomvalues": "10.1.12",
+        "@polkadot/x-bigint": "10.1.13",
+        "@polkadot/x-randomvalues": "10.1.13",
         "@scure/base": "1.1.1",
         "ed2curve": "^0.3.0",
         "tweetnacl": "^1.0.3"
@@ -1038,7 +1026,7 @@
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "@polkadot/util": "10.1.12"
+        "@polkadot/util": "10.1.13"
       }
     },
     "node_modules/@polkadot/wasm-bridge": {
@@ -1138,24 +1126,24 @@
       }
     },
     "node_modules/@polkadot/x-bigint": {
-      "version": "10.1.12",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-10.1.12.tgz",
-      "integrity": "sha512-n9cRXhdPvA9qO9/dgb32Ej/5t4mI4KnBYoPqlAcGviOnn7lc9yEPlYSMfgt+4p7F2bX8o6nbmbvBXqZL457Yhw==",
+      "version": "10.1.13",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-10.1.13.tgz",
+      "integrity": "sha512-froRz2AC8pJ8TTmPUf7SRyWVO/U7GNjuVEtxumOv9IT6YOohV8N4zBdZVCc4Cr0dEAvGWAS11b0EgTyzBirq3A==",
       "dependencies": {
         "@babel/runtime": "^7.20.1",
-        "@polkadot/x-global": "10.1.12"
+        "@polkadot/x-global": "10.1.13"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/x-fetch": {
-      "version": "10.1.12",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-10.1.12.tgz",
-      "integrity": "sha512-t40R3Vi2itsqT9bDAGxNYSV1+D8JQX4gCQoA8jQSjQe5xfSF9WidbcvDONsPhsunYe8gOb0FhdNm7ruuAdPNNw==",
+      "version": "10.1.13",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-10.1.13.tgz",
+      "integrity": "sha512-40WfW3rLMP1WfYrA0YlBnYWyNF5/lwSOpoQfnJ2vQHDvGRNmIJrQUAgxgjRjOVd+KKKE9e8s3W7TqjVhfoxrkQ==",
       "dependencies": {
         "@babel/runtime": "^7.20.1",
-        "@polkadot/x-global": "10.1.12",
+        "@polkadot/x-global": "10.1.13",
         "@types/node-fetch": "^2.6.2",
         "node-fetch": "^3.3.0"
       },
@@ -1164,9 +1152,9 @@
       }
     },
     "node_modules/@polkadot/x-global": {
-      "version": "10.1.12",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.1.12.tgz",
-      "integrity": "sha512-APFCIVoyaB9rhgcg2j5ayW0WVTSDO4yUriyrOPgX4A4ZJ6DFV+w30h9uWtfKzNzAV6dDs6pDNlB0K4Mpi5CmcA==",
+      "version": "10.1.13",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.1.13.tgz",
+      "integrity": "sha512-9dQNjrXzdnjMFdpS1fcJRJveD8aQ2qyO5XWYnUmDjWVPmTY+olNuv7QOkfoJUgrFhqgeGEtUCmPZEWk8Tbwhqw==",
       "dependencies": {
         "@babel/runtime": "^7.20.1"
       },
@@ -1175,48 +1163,48 @@
       }
     },
     "node_modules/@polkadot/x-randomvalues": {
-      "version": "10.1.12",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-10.1.12.tgz",
-      "integrity": "sha512-oldth/zJAwysb+1uSxB7GIgCnuJmK33ZbxRl8vOwHrIKgKJGxJufRxLtZg1Pq530DW6V3z5TwOWacx58ggfN3Q==",
+      "version": "10.1.13",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-10.1.13.tgz",
+      "integrity": "sha512-yDXvOUiXIdysigOxNgTX0cJ5PF8qYXdn15PGyGFROKdBV5NW4Fn27xfFtNC0vpsbHl2G5KfE55uBdKwOkEvJVg==",
       "dependencies": {
         "@babel/runtime": "^7.20.1",
-        "@polkadot/x-global": "10.1.12"
+        "@polkadot/x-global": "10.1.13"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/x-textdecoder": {
-      "version": "10.1.12",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-10.1.12.tgz",
-      "integrity": "sha512-YKEr3QiTu8zxosVx9WWFhMmFw4hBmAKWkgd7dhpMU+wIaUlSBriV/7vL+HnvJMIKf1jz3iAZ7i0oDGfvj1cZ6w==",
+      "version": "10.1.13",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-10.1.13.tgz",
+      "integrity": "sha512-4i5u48ELGPN2D4Bq12q0ZZEx8uhd0M0sajpEwqGclOLYvMt/Uh3S6WA4rxHCwVd8z76NFiipw+HOBkdAaYzbqA==",
       "dependencies": {
         "@babel/runtime": "^7.20.1",
-        "@polkadot/x-global": "10.1.12"
+        "@polkadot/x-global": "10.1.13"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/x-textencoder": {
-      "version": "10.1.12",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-10.1.12.tgz",
-      "integrity": "sha512-WgHAUhiepWBAcOMOAJnBl2mZNu5KPmTndg4f1Z1CwNdg/AhAhJL/yh98f5KH1aajNkC+5xutlOzdmEySg+e21g==",
+      "version": "10.1.13",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-10.1.13.tgz",
+      "integrity": "sha512-tkCgEydGChSXWhOuZYOOJ5DkdQq3Ev9zhs1cVdp1O72f/E7L6iv06WmfiFBeF+cX1/ymI3++IrOZqPI+t29gnA==",
       "dependencies": {
         "@babel/runtime": "^7.20.1",
-        "@polkadot/x-global": "10.1.12"
+        "@polkadot/x-global": "10.1.13"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/x-ws": {
-      "version": "10.1.12",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-10.1.12.tgz",
-      "integrity": "sha512-MmPNHAVBhCkd9Cv6i/ctcVC5Fo8fEeIlBk/GTOZSaLQZAP9jqFPrZZQE7n4oFLSw645z+RjlBodd3Y9Q9acfMg==",
+      "version": "10.1.13",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-10.1.13.tgz",
+      "integrity": "sha512-hs9v/i0bAcmazZI0R8kgao3/NzBxTMFzUVEbH11yDzL3RCWKYPIbeK4VwI31VUOzIIsjhNgCegSueJMkLn4F5Q==",
       "dependencies": {
         "@babel/runtime": "^7.20.1",
-        "@polkadot/x-global": "10.1.12",
+        "@polkadot/x-global": "10.1.13",
         "@types/websocket": "^1.0.5",
         "websocket": "^1.0.34"
       },
@@ -1280,12 +1268,12 @@
       "dev": true
     },
     "node_modules/@substrate/connect": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.7.9.tgz",
-      "integrity": "sha512-E6bdBhzsfHNAKlmQSvbTW1jyb0WcIvgbrEBfJ4B6FZ3t1wpGjldL6GrYtegVtKr9/ySQ/pFNn0uVbugukpMDjQ==",
+      "version": "0.7.17",
+      "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.7.17.tgz",
+      "integrity": "sha512-s0XBmGpUCFWZFa+TS0TEvOKtWjJP2uT4xKmvzApH8INB5xbz79wqWFX6WWh3AlK/X1P0Smt+RVEH7HQiLJAYAw==",
       "dependencies": {
         "@substrate/connect-extension-protocol": "^1.0.1",
-        "@substrate/smoldot-light": "0.6.25",
+        "@substrate/smoldot-light": "0.7.7",
         "eventemitter3": "^4.0.7"
       }
     },
@@ -1295,17 +1283,18 @@
       "integrity": "sha512-161JhCC1csjH3GE5mPLEd7HbWtwNSPJBg3p1Ksz9SFlTzj/bgEwudiRN2y5i0MoLGCIJRYKyKGMxVnd29PzNjg=="
     },
     "node_modules/@substrate/smoldot-light": {
-      "version": "0.6.25",
-      "resolved": "https://registry.npmjs.org/@substrate/smoldot-light/-/smoldot-light-0.6.25.tgz",
-      "integrity": "sha512-OQ9/bnJJy90xSRg5Vp9MIvrgbrVt/r/FwXYSmyLeBBNbJt6o1gSeshVo8icD+2VWwd/TJ2oHl5CVQWe89MyByA==",
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/@substrate/smoldot-light/-/smoldot-light-0.7.7.tgz",
+      "integrity": "sha512-ksxeAed6dIUtYSl0f8ehgWQjwXnpDGTIJt+WVRIGt3OObZkA96ZdBWx0xP7GrXZtj37u4n/Y1z7TyTm4bwQvrw==",
       "dependencies": {
-        "websocket": "^1.0.32"
+        "pako": "^2.0.4",
+        "ws": "^8.8.1"
       }
     },
     "node_modules/@substrate/ss58-registry": {
-      "version": "1.34.0",
-      "resolved": "https://registry.npmjs.org/@substrate/ss58-registry/-/ss58-registry-1.34.0.tgz",
-      "integrity": "sha512-8Df5usnWvjnw/WRAmKOqHXRPPRfiCd1kIN8ttH4YmBrRTERjVInsdu0xvLdbyUYKyvgK6zKhHWQfYohXqllHhg=="
+      "version": "1.35.0",
+      "resolved": "https://registry.npmjs.org/@substrate/ss58-registry/-/ss58-registry-1.35.0.tgz",
+      "integrity": "sha512-cIY3J7RlT4mfPNFwd2mv1q9vTp/shImw2gN2y2outMhOcagH/HG+W8/JohpifjxPC/1pbQ0Z8nxfL5Td3EchcA=="
     },
     "node_modules/@types/bn.js": {
       "version": "5.1.1",
@@ -5553,6 +5542,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -7253,6 +7247,26 @@
         "typedarray-to-buffer": "^3.1.5"
       }
     },
+    "node_modules/ws": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -7632,14 +7646,6 @@
         "to-fast-properties": "^2.0.0"
       }
     },
-    "@digicatapult/dscp-node": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@digicatapult/dscp-node/-/dscp-node-4.4.6.tgz",
-      "integrity": "sha512-h8R2h9mfW3YrhwZ3P3KPKV+uGOlj6kIMBXv7vQmg9cA+0yCBUHHUNwUQp7jpudV7cpTFzV6QNSw9k21IrTGi/w==",
-      "requires": {
-        "@polkadot/api": "^8.11.3"
-      }
-    },
     "@eslint/eslintrc": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
@@ -7871,232 +7877,232 @@
       "integrity": "sha512-UdkG3mLEqXgnlKsWanWcgb6dOjUzJ+XC5f+aWw30qrtjxeNUSfKX1cd5FBzOaXQumoe9nIqeZUvrRJS03HCCtw=="
     },
     "@polkadot/api": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-8.14.1.tgz",
-      "integrity": "sha512-jg26eIKFYqVfDBTAopHL3aDaNw9j6TdUkXuvYJOnynpecU4xwbTVKcOtSOjJ2eRX4MgMQ4zlyMHJx3iKw0uUTA==",
+      "version": "9.9.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-9.9.1.tgz",
+      "integrity": "sha512-3ltj6BbqEV9SCUlJIEmXWBmmQlZCvVPaj0N+99J9L2yiQ1E0KJsAizh10RxEjCvgYb2iWaE4ItPfhN0GxFJm7Q==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/api-augment": "8.14.1",
-        "@polkadot/api-base": "8.14.1",
-        "@polkadot/api-derive": "8.14.1",
-        "@polkadot/keyring": "^10.1.1",
-        "@polkadot/rpc-augment": "8.14.1",
-        "@polkadot/rpc-core": "8.14.1",
-        "@polkadot/rpc-provider": "8.14.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-augment": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/types-create": "8.14.1",
-        "@polkadot/types-known": "8.14.1",
-        "@polkadot/util": "^10.1.1",
-        "@polkadot/util-crypto": "^10.1.1",
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/api-augment": "9.9.1",
+        "@polkadot/api-base": "9.9.1",
+        "@polkadot/api-derive": "9.9.1",
+        "@polkadot/keyring": "^10.1.13",
+        "@polkadot/rpc-augment": "9.9.1",
+        "@polkadot/rpc-core": "9.9.1",
+        "@polkadot/rpc-provider": "9.9.1",
+        "@polkadot/types": "9.9.1",
+        "@polkadot/types-augment": "9.9.1",
+        "@polkadot/types-codec": "9.9.1",
+        "@polkadot/types-create": "9.9.1",
+        "@polkadot/types-known": "9.9.1",
+        "@polkadot/util": "^10.1.13",
+        "@polkadot/util-crypto": "^10.1.13",
         "eventemitter3": "^4.0.7",
-        "rxjs": "^7.5.6"
+        "rxjs": "^7.5.7"
       }
     },
     "@polkadot/api-augment": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-8.14.1.tgz",
-      "integrity": "sha512-65GMlgVnZd08Ifh8uAj+p/+MlXxvsAfBcCHjQhOmbCE0dki+rzTPUR31LsWyDKtuw+nUBj0iZN4PelO+wU4r0g==",
+      "version": "9.9.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-9.9.1.tgz",
+      "integrity": "sha512-0HS6Kit9ZiO2iQU/aS/jpOjXl9rFcwW6FdUs1eSXvWjvAFpoxwCMG8bv8wVjNZcCUuA2w5U0+2B+Xa612QEQQg==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/api-base": "8.14.1",
-        "@polkadot/rpc-augment": "8.14.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-augment": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/util": "^10.1.1"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/api-base": "9.9.1",
+        "@polkadot/rpc-augment": "9.9.1",
+        "@polkadot/types": "9.9.1",
+        "@polkadot/types-augment": "9.9.1",
+        "@polkadot/types-codec": "9.9.1",
+        "@polkadot/util": "^10.1.13"
       }
     },
     "@polkadot/api-base": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-8.14.1.tgz",
-      "integrity": "sha512-EXFhNXIfpirf18IsqcG2pGQW1/Xn+bfjqVYQMMJ4ZONtYH4baZZlXk7SoXCCHonN2x1ixs4DOcRx5oVxjabdIQ==",
+      "version": "9.9.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-9.9.1.tgz",
+      "integrity": "sha512-uJDLi+nHQ08QZ+p1ldzwMeNjCyIkpR1DOzvKV3M3bLepglF8r7V/7W5dXk+qlClMqgB92RgKwo4R6EPRgr5BcA==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/rpc-core": "8.14.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/util": "^10.1.1",
-        "rxjs": "^7.5.6"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/rpc-core": "9.9.1",
+        "@polkadot/types": "9.9.1",
+        "@polkadot/util": "^10.1.13",
+        "rxjs": "^7.5.7"
       }
     },
     "@polkadot/api-derive": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-8.14.1.tgz",
-      "integrity": "sha512-eWG1MrQhHMUjt9gDHN9/9/ZMATu1MolqcalPFhNoGtdON3+I0J3ntjQ4y5X7+p2OGwQplpYRKqbK4k7tKzu8tA==",
+      "version": "9.9.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-9.9.1.tgz",
+      "integrity": "sha512-cCCbnhXfCo9Mj4DCM0TVoDOEe5yleOLdqoICU9T4PMv5R51D+iMmw97+MYCgyjRdm7wIW05LlW32iUVrgDiSJw==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/api": "8.14.1",
-        "@polkadot/api-augment": "8.14.1",
-        "@polkadot/api-base": "8.14.1",
-        "@polkadot/rpc-core": "8.14.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/util": "^10.1.1",
-        "@polkadot/util-crypto": "^10.1.1",
-        "rxjs": "^7.5.6"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/api": "9.9.1",
+        "@polkadot/api-augment": "9.9.1",
+        "@polkadot/api-base": "9.9.1",
+        "@polkadot/rpc-core": "9.9.1",
+        "@polkadot/types": "9.9.1",
+        "@polkadot/types-codec": "9.9.1",
+        "@polkadot/util": "^10.1.13",
+        "@polkadot/util-crypto": "^10.1.13",
+        "rxjs": "^7.5.7"
       }
     },
     "@polkadot/keyring": {
-      "version": "10.1.12",
-      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-10.1.12.tgz",
-      "integrity": "sha512-zwTWOa+Glg0NT+EoOOjg9U6dotGPxDpr8xdpkg9EXcyKMa5Pw7alrUg+V3tC+5Ttu7dsZRCJKW8jEshCekulWA==",
+      "version": "10.1.13",
+      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-10.1.13.tgz",
+      "integrity": "sha512-O5/sM1cfn/ueT7C6sxqZI9Z18RLOpPovdfZzBlcRAyfs/8uR+UA20r2lGCQdQIzlOeF0XPebIO0lwW+6wPtvtg==",
       "requires": {
         "@babel/runtime": "^7.20.1",
-        "@polkadot/util": "10.1.12",
-        "@polkadot/util-crypto": "10.1.12"
+        "@polkadot/util": "10.1.13",
+        "@polkadot/util-crypto": "10.1.13"
       }
     },
     "@polkadot/networks": {
-      "version": "10.1.12",
-      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-10.1.12.tgz",
-      "integrity": "sha512-asobCUdRSsnSIZKoqFsaPPtUPvbaNPh3r1XOvNqgrE65wsoNx15AiuqAigW2RKOoqVrUW7zthRJ5Xmk0MKS9GA==",
+      "version": "10.1.13",
+      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-10.1.13.tgz",
+      "integrity": "sha512-EvR0weOZlTS9AzQd8/s7WJrLCfAdaP3fKPSoaJkir1fUrpmhagMZaIm+kHmKO3lqEaqV+EAZm3Ee43bZN0na7A==",
       "requires": {
         "@babel/runtime": "^7.20.1",
-        "@polkadot/util": "10.1.12",
+        "@polkadot/util": "10.1.13",
         "@substrate/ss58-registry": "^1.34.0"
       }
     },
     "@polkadot/rpc-augment": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-8.14.1.tgz",
-      "integrity": "sha512-0dIsNVIMeCp0kV7+Obz0Odt6K32Ka2ygwhiV5jhhJthy8GJBPo94mKDed5gzln3Dgl2LEdJJt1h/pgCx4a2i4A==",
+      "version": "9.9.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-9.9.1.tgz",
+      "integrity": "sha512-t3gTendxM9KD9Sg+hT7Wn72Xdusl25EsXcdOjFqQWUtFL8xjYcFngrTTifG90e+ciFIk1DWps2+zc6lbDwBfeA==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/rpc-core": "8.14.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/util": "^10.1.1"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/rpc-core": "9.9.1",
+        "@polkadot/types": "9.9.1",
+        "@polkadot/types-codec": "9.9.1",
+        "@polkadot/util": "^10.1.13"
       }
     },
     "@polkadot/rpc-core": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-8.14.1.tgz",
-      "integrity": "sha512-deQ8Ob59ao/1fZQdaVtFjYR/HCBdxSYvQGt7/alBu1Uig9Sahx9oKcMkU5rWY36XqGZYos4zLay98W2hDlf+6Q==",
+      "version": "9.9.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-9.9.1.tgz",
+      "integrity": "sha512-ij1OxDfbPpdZ9+aN8oicZrysIfUjC7INBhDwwoZ4R/4jhqJvIV1fisgj6XOdHGlZGl+vQBnObOw0nEOU7apdQg==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/rpc-augment": "8.14.1",
-        "@polkadot/rpc-provider": "8.14.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/util": "^10.1.1",
-        "rxjs": "^7.5.6"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/rpc-augment": "9.9.1",
+        "@polkadot/rpc-provider": "9.9.1",
+        "@polkadot/types": "9.9.1",
+        "@polkadot/util": "^10.1.13",
+        "rxjs": "^7.5.7"
       }
     },
     "@polkadot/rpc-provider": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-8.14.1.tgz",
-      "integrity": "sha512-pAUSHZiSWLhBSYf4LmLc8iCaeqTu7Ajn8AzyqxvZDHGnIrzV5M7eTjpNDP84qno6jWRHKQ/IILr62hausEmS5w==",
+      "version": "9.9.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-9.9.1.tgz",
+      "integrity": "sha512-YyIwYDAgeEAAjvsH/v5v6sFkhkoaER98rPIcfP+81sGcxpjBCArg4feDtzTPQMsnUcbj3708ppJicu6ECc1xFg==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/keyring": "^10.1.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-support": "8.14.1",
-        "@polkadot/util": "^10.1.1",
-        "@polkadot/util-crypto": "^10.1.1",
-        "@polkadot/x-fetch": "^10.1.1",
-        "@polkadot/x-global": "^10.1.1",
-        "@polkadot/x-ws": "^10.1.1",
-        "@substrate/connect": "0.7.9",
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/keyring": "^10.1.13",
+        "@polkadot/types": "9.9.1",
+        "@polkadot/types-support": "9.9.1",
+        "@polkadot/util": "^10.1.13",
+        "@polkadot/util-crypto": "^10.1.13",
+        "@polkadot/x-fetch": "^10.1.13",
+        "@polkadot/x-global": "^10.1.13",
+        "@polkadot/x-ws": "^10.1.13",
+        "@substrate/connect": "0.7.17",
         "eventemitter3": "^4.0.7",
         "mock-socket": "^9.1.5",
         "nock": "^13.2.9"
       }
     },
     "@polkadot/types": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-8.14.1.tgz",
-      "integrity": "sha512-Xza16ejKrSd4XhTOlbfISyxZ2sRmbMAZk5pX7VEMHVZHqV98o+bJ2f9Kk7F8YJijkHHGosCLDestP9R5nLoOoA==",
+      "version": "9.9.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-9.9.1.tgz",
+      "integrity": "sha512-WK0CPj0LZhb5ZSfhMvT5ZZv0nnqz9wQdRSehjqeuq7DD2TgTIPZL22zP4UjJPAJEyTtwyfcRn6+ZhL2JS5w0Jg==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/keyring": "^10.1.1",
-        "@polkadot/types-augment": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/types-create": "8.14.1",
-        "@polkadot/util": "^10.1.1",
-        "@polkadot/util-crypto": "^10.1.1",
-        "rxjs": "^7.5.6"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/keyring": "^10.1.13",
+        "@polkadot/types-augment": "9.9.1",
+        "@polkadot/types-codec": "9.9.1",
+        "@polkadot/types-create": "9.9.1",
+        "@polkadot/util": "^10.1.13",
+        "@polkadot/util-crypto": "^10.1.13",
+        "rxjs": "^7.5.7"
       }
     },
     "@polkadot/types-augment": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-8.14.1.tgz",
-      "integrity": "sha512-Xa4TUFqyZT+IJ6pBSwDjWcF42u/E34OyC+gbs5Z2vWQ4EzSDkq4xNoUKjJlEEgTemsD9lhPOIc4jvqTCefwxEw==",
+      "version": "9.9.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-9.9.1.tgz",
+      "integrity": "sha512-h4DhtVPbe7/6Mdwickqih3ltvEV9y08a8LVvjxVVaGw1gRcoQpcMLkvsyWh5caYBPCKuJvXV40p4PnvO/HtW2A==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/util": "^10.1.1"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/types": "9.9.1",
+        "@polkadot/types-codec": "9.9.1",
+        "@polkadot/util": "^10.1.13"
       }
     },
     "@polkadot/types-codec": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-8.14.1.tgz",
-      "integrity": "sha512-y6YDN4HwvEgSWlgrEV04QBBxDxES1cTuUQFzZJzOTuZCWpA371Mdj3M9wYxGXMnj0wa+rCQGECHPZZaNxBMiKg==",
+      "version": "9.9.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-9.9.1.tgz",
+      "integrity": "sha512-vBzInneVp2ClDD/bmrf9HUp9La0udBJnhvyqwdLA2IKQBjIYOxVtuC62D4dg1Svp34NH4+b/nAtWlOvflSjOQQ==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/util": "^10.1.1",
-        "@polkadot/x-bigint": "^10.1.1"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/util": "^10.1.13",
+        "@polkadot/x-bigint": "^10.1.13"
       }
     },
     "@polkadot/types-create": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-8.14.1.tgz",
-      "integrity": "sha512-fb9yyblj5AYAPzeCIq0kYSfzDxRDi/0ud9gN2UzB3H7M/O4n2mPC1vD4UOLF+B7l9QzCrt4e+k+/riGp7GfvyA==",
+      "version": "9.9.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-9.9.1.tgz",
+      "integrity": "sha512-fzHTdWdXPbJxAYNP2nFzM9B1Nom7wiIFalltIj3jLQYF8uCgPuMF4/nLDi5uEg5YpCBCTagqyoVUuEd4riDS/Q==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/util": "^10.1.1"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/types-codec": "9.9.1",
+        "@polkadot/util": "^10.1.13"
       }
     },
     "@polkadot/types-known": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-8.14.1.tgz",
-      "integrity": "sha512-GP7gRo9nmitykkrRnoLF61Qm19UFdTwMsOnJkdm7AOeWDmZGxutacgO6k1tBsHr38hsiCCGsB/JiseUgywvGIw==",
+      "version": "9.9.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-9.9.1.tgz",
+      "integrity": "sha512-kD51etsC0Oh5RnBTVabxmIqXe03XRYBDAaaC6yj2MGiPsyuy3X6g26xPZy9pSYcjkkWIF81CtPcLaJE5YrG0/A==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/networks": "^10.1.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/types-create": "8.14.1",
-        "@polkadot/util": "^10.1.1"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/networks": "^10.1.13",
+        "@polkadot/types": "9.9.1",
+        "@polkadot/types-codec": "9.9.1",
+        "@polkadot/types-create": "9.9.1",
+        "@polkadot/util": "^10.1.13"
       }
     },
     "@polkadot/types-support": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-8.14.1.tgz",
-      "integrity": "sha512-XqR4qq6pCZyNBuFVod8nFSNUmLssrjoU9bOIn4Ua2cqNlI9xsuKaI1X5ySEn/oWOtKQ2L5hbCm9vkXrEtXBl1w==",
+      "version": "9.9.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-9.9.1.tgz",
+      "integrity": "sha512-PGu80mMvyr+rD6pi8Z/r9l650cadpW4X+pWt4tJnKYAbtiaE9mQJGFwq+HgY3vExzRDhaXNOUDg9d1ry5XUvJQ==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/util": "^10.1.1"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/util": "^10.1.13"
       }
     },
     "@polkadot/util": {
-      "version": "10.1.12",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.1.12.tgz",
-      "integrity": "sha512-bOz1WqDFzIgkTpT6oRhAdXKqETr2GffZdRlYqyOvP1ATAEa48/sRgzIvg7WTiI68D8By3fJmKuA+ggX3YrNF/w==",
+      "version": "10.1.13",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.1.13.tgz",
+      "integrity": "sha512-wedd6NKIA1gKUm21SFwsq8UzQrMAzc2fBjrfD07LIXEJ2S/q5IKF57NjGMzf6fdNFt0376VNLUGD4MbxSc9/HA==",
       "requires": {
         "@babel/runtime": "^7.20.1",
-        "@polkadot/x-bigint": "10.1.12",
-        "@polkadot/x-global": "10.1.12",
-        "@polkadot/x-textdecoder": "10.1.12",
-        "@polkadot/x-textencoder": "10.1.12",
+        "@polkadot/x-bigint": "10.1.13",
+        "@polkadot/x-global": "10.1.13",
+        "@polkadot/x-textdecoder": "10.1.13",
+        "@polkadot/x-textencoder": "10.1.13",
         "@types/bn.js": "^5.1.1",
         "bn.js": "^5.2.1"
       }
     },
     "@polkadot/util-crypto": {
-      "version": "10.1.12",
-      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-10.1.12.tgz",
-      "integrity": "sha512-X/IxeMMYMVWhByU2be5bzPFy8acPTa2oLcvzSKLjhxqtCEIqprs/fshhfT3qVTa/lAN+WeNE8oTPCPLKVpQE4w==",
+      "version": "10.1.13",
+      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-10.1.13.tgz",
+      "integrity": "sha512-LYHsJM8hzsvehO2T1S5vMFX7k2gCt/QnG3NzSGo+97OauitrICN8V7py4o5TOewUzMeihNMVKjRkj/cC4e+i4Q==",
       "requires": {
         "@babel/runtime": "^7.20.1",
         "@noble/hashes": "1.1.3",
         "@noble/secp256k1": "1.7.0",
-        "@polkadot/networks": "10.1.12",
-        "@polkadot/util": "10.1.12",
+        "@polkadot/networks": "10.1.13",
+        "@polkadot/util": "10.1.13",
         "@polkadot/wasm-crypto": "^6.3.1",
-        "@polkadot/x-bigint": "10.1.12",
-        "@polkadot/x-randomvalues": "10.1.12",
+        "@polkadot/x-bigint": "10.1.13",
+        "@polkadot/x-randomvalues": "10.1.13",
         "@scure/base": "1.1.1",
         "ed2curve": "^0.3.0",
         "tweetnacl": "^1.0.3"
@@ -8160,67 +8166,67 @@
       }
     },
     "@polkadot/x-bigint": {
-      "version": "10.1.12",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-10.1.12.tgz",
-      "integrity": "sha512-n9cRXhdPvA9qO9/dgb32Ej/5t4mI4KnBYoPqlAcGviOnn7lc9yEPlYSMfgt+4p7F2bX8o6nbmbvBXqZL457Yhw==",
+      "version": "10.1.13",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-10.1.13.tgz",
+      "integrity": "sha512-froRz2AC8pJ8TTmPUf7SRyWVO/U7GNjuVEtxumOv9IT6YOohV8N4zBdZVCc4Cr0dEAvGWAS11b0EgTyzBirq3A==",
       "requires": {
         "@babel/runtime": "^7.20.1",
-        "@polkadot/x-global": "10.1.12"
+        "@polkadot/x-global": "10.1.13"
       }
     },
     "@polkadot/x-fetch": {
-      "version": "10.1.12",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-10.1.12.tgz",
-      "integrity": "sha512-t40R3Vi2itsqT9bDAGxNYSV1+D8JQX4gCQoA8jQSjQe5xfSF9WidbcvDONsPhsunYe8gOb0FhdNm7ruuAdPNNw==",
+      "version": "10.1.13",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-10.1.13.tgz",
+      "integrity": "sha512-40WfW3rLMP1WfYrA0YlBnYWyNF5/lwSOpoQfnJ2vQHDvGRNmIJrQUAgxgjRjOVd+KKKE9e8s3W7TqjVhfoxrkQ==",
       "requires": {
         "@babel/runtime": "^7.20.1",
-        "@polkadot/x-global": "10.1.12",
+        "@polkadot/x-global": "10.1.13",
         "@types/node-fetch": "^2.6.2",
         "node-fetch": "^3.3.0"
       }
     },
     "@polkadot/x-global": {
-      "version": "10.1.12",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.1.12.tgz",
-      "integrity": "sha512-APFCIVoyaB9rhgcg2j5ayW0WVTSDO4yUriyrOPgX4A4ZJ6DFV+w30h9uWtfKzNzAV6dDs6pDNlB0K4Mpi5CmcA==",
+      "version": "10.1.13",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.1.13.tgz",
+      "integrity": "sha512-9dQNjrXzdnjMFdpS1fcJRJveD8aQ2qyO5XWYnUmDjWVPmTY+olNuv7QOkfoJUgrFhqgeGEtUCmPZEWk8Tbwhqw==",
       "requires": {
         "@babel/runtime": "^7.20.1"
       }
     },
     "@polkadot/x-randomvalues": {
-      "version": "10.1.12",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-10.1.12.tgz",
-      "integrity": "sha512-oldth/zJAwysb+1uSxB7GIgCnuJmK33ZbxRl8vOwHrIKgKJGxJufRxLtZg1Pq530DW6V3z5TwOWacx58ggfN3Q==",
+      "version": "10.1.13",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-10.1.13.tgz",
+      "integrity": "sha512-yDXvOUiXIdysigOxNgTX0cJ5PF8qYXdn15PGyGFROKdBV5NW4Fn27xfFtNC0vpsbHl2G5KfE55uBdKwOkEvJVg==",
       "requires": {
         "@babel/runtime": "^7.20.1",
-        "@polkadot/x-global": "10.1.12"
+        "@polkadot/x-global": "10.1.13"
       }
     },
     "@polkadot/x-textdecoder": {
-      "version": "10.1.12",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-10.1.12.tgz",
-      "integrity": "sha512-YKEr3QiTu8zxosVx9WWFhMmFw4hBmAKWkgd7dhpMU+wIaUlSBriV/7vL+HnvJMIKf1jz3iAZ7i0oDGfvj1cZ6w==",
+      "version": "10.1.13",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-10.1.13.tgz",
+      "integrity": "sha512-4i5u48ELGPN2D4Bq12q0ZZEx8uhd0M0sajpEwqGclOLYvMt/Uh3S6WA4rxHCwVd8z76NFiipw+HOBkdAaYzbqA==",
       "requires": {
         "@babel/runtime": "^7.20.1",
-        "@polkadot/x-global": "10.1.12"
+        "@polkadot/x-global": "10.1.13"
       }
     },
     "@polkadot/x-textencoder": {
-      "version": "10.1.12",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-10.1.12.tgz",
-      "integrity": "sha512-WgHAUhiepWBAcOMOAJnBl2mZNu5KPmTndg4f1Z1CwNdg/AhAhJL/yh98f5KH1aajNkC+5xutlOzdmEySg+e21g==",
+      "version": "10.1.13",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-10.1.13.tgz",
+      "integrity": "sha512-tkCgEydGChSXWhOuZYOOJ5DkdQq3Ev9zhs1cVdp1O72f/E7L6iv06WmfiFBeF+cX1/ymI3++IrOZqPI+t29gnA==",
       "requires": {
         "@babel/runtime": "^7.20.1",
-        "@polkadot/x-global": "10.1.12"
+        "@polkadot/x-global": "10.1.13"
       }
     },
     "@polkadot/x-ws": {
-      "version": "10.1.12",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-10.1.12.tgz",
-      "integrity": "sha512-MmPNHAVBhCkd9Cv6i/ctcVC5Fo8fEeIlBk/GTOZSaLQZAP9jqFPrZZQE7n4oFLSw645z+RjlBodd3Y9Q9acfMg==",
+      "version": "10.1.13",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-10.1.13.tgz",
+      "integrity": "sha512-hs9v/i0bAcmazZI0R8kgao3/NzBxTMFzUVEbH11yDzL3RCWKYPIbeK4VwI31VUOzIIsjhNgCegSueJMkLn4F5Q==",
       "requires": {
         "@babel/runtime": "^7.20.1",
-        "@polkadot/x-global": "10.1.12",
+        "@polkadot/x-global": "10.1.13",
         "@types/websocket": "^1.0.5",
         "websocket": "^1.0.34"
       }
@@ -8277,12 +8283,12 @@
       "dev": true
     },
     "@substrate/connect": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.7.9.tgz",
-      "integrity": "sha512-E6bdBhzsfHNAKlmQSvbTW1jyb0WcIvgbrEBfJ4B6FZ3t1wpGjldL6GrYtegVtKr9/ySQ/pFNn0uVbugukpMDjQ==",
+      "version": "0.7.17",
+      "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.7.17.tgz",
+      "integrity": "sha512-s0XBmGpUCFWZFa+TS0TEvOKtWjJP2uT4xKmvzApH8INB5xbz79wqWFX6WWh3AlK/X1P0Smt+RVEH7HQiLJAYAw==",
       "requires": {
         "@substrate/connect-extension-protocol": "^1.0.1",
-        "@substrate/smoldot-light": "0.6.25",
+        "@substrate/smoldot-light": "0.7.7",
         "eventemitter3": "^4.0.7"
       }
     },
@@ -8292,17 +8298,18 @@
       "integrity": "sha512-161JhCC1csjH3GE5mPLEd7HbWtwNSPJBg3p1Ksz9SFlTzj/bgEwudiRN2y5i0MoLGCIJRYKyKGMxVnd29PzNjg=="
     },
     "@substrate/smoldot-light": {
-      "version": "0.6.25",
-      "resolved": "https://registry.npmjs.org/@substrate/smoldot-light/-/smoldot-light-0.6.25.tgz",
-      "integrity": "sha512-OQ9/bnJJy90xSRg5Vp9MIvrgbrVt/r/FwXYSmyLeBBNbJt6o1gSeshVo8icD+2VWwd/TJ2oHl5CVQWe89MyByA==",
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/@substrate/smoldot-light/-/smoldot-light-0.7.7.tgz",
+      "integrity": "sha512-ksxeAed6dIUtYSl0f8ehgWQjwXnpDGTIJt+WVRIGt3OObZkA96ZdBWx0xP7GrXZtj37u4n/Y1z7TyTm4bwQvrw==",
       "requires": {
-        "websocket": "^1.0.32"
+        "pako": "^2.0.4",
+        "ws": "^8.8.1"
       }
     },
     "@substrate/ss58-registry": {
-      "version": "1.34.0",
-      "resolved": "https://registry.npmjs.org/@substrate/ss58-registry/-/ss58-registry-1.34.0.tgz",
-      "integrity": "sha512-8Df5usnWvjnw/WRAmKOqHXRPPRfiCd1kIN8ttH4YmBrRTERjVInsdu0xvLdbyUYKyvgK6zKhHWQfYohXqllHhg=="
+      "version": "1.35.0",
+      "resolved": "https://registry.npmjs.org/@substrate/ss58-registry/-/ss58-registry-1.35.0.tgz",
+      "integrity": "sha512-cIY3J7RlT4mfPNFwd2mv1q9vTp/shImw2gN2y2outMhOcagH/HG+W8/JohpifjxPC/1pbQ0Z8nxfL5Td3EchcA=="
     },
     "@types/bn.js": {
       "version": "5.1.1",
@@ -11575,6 +11582,11 @@
         "release-zalgo": "^1.0.0"
       }
     },
+    "pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
+    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -12866,6 +12878,12 @@
         "signal-exit": "^3.0.2",
         "typedarray-to-buffer": "^3.1.5"
       }
+    },
+    "ws": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+      "requires": {}
     },
     "xtend": {
       "version": "4.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dscp-api",
-  "version": "4.8.1",
+  "version": "4.8.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dscp-api",
-      "version": "4.8.1",
+      "version": "4.8.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^9.9.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "coverage:merge": "LOG_LEVEL=fatal NODE_ENV=development nyc --no-clean npm run test && nyc --no-clean npm run test:jwt && nyc merge .nyc_output --timeout 60000 --slow 20000 --exit"
   },
   "dependencies": {
-    "@digicatapult/dscp-node": "^4.4.6",
+    "@polkadot/api": "^9.9.1",
     "base-x": "^4.0.0",
     "body-parser": "^1.20.1",
     "compression": "^1.7.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dscp-api",
-  "version": "4.8.1",
+  "version": "4.8.2",
   "description": "DSCP API",
   "type": "module",
   "repository": {


### PR DESCRIPTION
Since `dscp-node` was updated to use a more recent tag of Substrate, we no longer need the `dscp-node` extended types config when connecting to the node via polkadot.js  

This means we can remove usage of `@digicatapult/dscp-node` package and replace with direct use of `@polkadot/api`