### PR TITLE
Add external AUTH_TYPE

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,36 +52,35 @@ npm run test:integration
 
 The following environment variables are used by `veritable-api` and can be configured. Entries marked as `required` are needed when running `veritable-api` in production mode.
 
-| variable                        | required |        default         | description                                                                                  |
-| :------------------------------ | :------: | :--------------------: | :------------------------------------------------------------------------------------------- |
-| PORT                            |    N     |         `3001`         | The port for the API to listen on                                                            |
-| EXTERNAL_ORIGIN                    |    N     |                        | The origin from which the OpenAPI service is accessible. If not provided the value will default to `http://localhost:${PORT}` |
-| EXTERNAL_PATH_PREFIX                    |    N     |                        | A path prefix from which this service is served |
-| API_HOST                        |    Y     |           -            | The hostname of the `dscp-node` the API should connect to                                    |
-| API_PORT                        |    N     |         `9944`         | The port of the `dscp-node` the API should connect to                                        |
-| LOG_LEVEL                       |    N     |         `info`         | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`]         |
-| USER_URI                        |    Y     |           -            | The Substrate `URI` representing the private key to use when making `dscp-node` transactions |
-| IPFS_HOST                       |    Y     |           -            | Hostname of the `IPFS` node to use for metadata storage                                      |
-| IPFS_PORT                       |    N     |        `15001`         | Port of the `IPFS` node to use for metadata storage                                          |
-| METADATA_KEY_LENGTH             |    N     |          `32`          | Fixed length of metadata keys                                                                |
-| METADATA_VALUE_LITERAL_LENGTH   |    N     |          `32`          | Fixed length of metadata LITERAL values                                                      |
-| API_VERSION                     |    N     | `package.json version` | API version                                                                                  |
-| API_MAJOR_VERSION               |    N     |          `v3`          | API major version                                                                            |
-| FILE_UPLOAD_MAX_SIZE            |    N     |  `200 * 1024 * 1024`   | The Maximum file upload size (bytes)                                                         |
-| SUBSTRATE_STATUS_POLL_PERIOD_MS |    N     |      `10 * 1000`       | Number of ms between calls to check dscp-node status                                         |
-| SUBSTRATE_STATUS_TIMEOUT_MS     |    N     |       `2 * 1000`       | Number of ms to wait for response to dscp-node health requests                               |
-| IPFS_STATUS_POLL_PERIOD_MS      |    N     |      `10 * 1000`       | Number of ms between calls to check ipfs status                                              |
-| IPFS_STATUS_TIMEOUT_MS          |    N     |       `2 * 1000`       | Number of ms to wait for response to ipfs health requests                                    |
-| AUTH_TYPE                       |    N     |         `NONE`         | Authentication type for routes on the service. Valid values: [`NONE`, `JWT`]                 |
+| variable                        | required |        default         | description                                                                                                                   |
+| :------------------------------ | :------: | :--------------------: | :---------------------------------------------------------------------------------------------------------------------------- |
+| PORT                            |    N     |         `3001`         | The port for the API to listen on                                                                                             |
+| EXTERNAL_ORIGIN                 |    N     |                        | The origin from which the OpenAPI service is accessible. If not provided the value will default to `http://localhost:${PORT}` |
+| EXTERNAL_PATH_PREFIX            |    N     |                        | A path prefix from which this service is served                                                                               |
+| API_HOST                        |    Y     |           -            | The hostname of the `dscp-node` the API should connect to                                                                     |
+| API_PORT                        |    N     |         `9944`         | The port of the `dscp-node` the API should connect to                                                                         |
+| LOG_LEVEL                       |    N     |         `info`         | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`]                                          |
+| USER_URI                        |    Y     |           -            | The Substrate `URI` representing the private key to use when making `dscp-node` transactions                                  |
+| IPFS_HOST                       |    Y     |           -            | Hostname of the `IPFS` node to use for metadata storage                                                                       |
+| IPFS_PORT                       |    N     |        `15001`         | Port of the `IPFS` node to use for metadata storage                                                                           |
+| METADATA_KEY_LENGTH             |    N     |          `32`          | Fixed length of metadata keys                                                                                                 |
+| METADATA_VALUE_LITERAL_LENGTH   |    N     |          `32`          | Fixed length of metadata LITERAL values                                                                                       |
+| API_VERSION                     |    N     | `package.json version` | API version                                                                                                                   |
+| API_MAJOR_VERSION               |    N     |          `v3`          | API major version                                                                                                             |
+| FILE_UPLOAD_MAX_SIZE            |    N     |  `200 * 1024 * 1024`   | The Maximum file upload size (bytes)                                                                                          |
+| SUBSTRATE_STATUS_POLL_PERIOD_MS |    N     |      `10 * 1000`       | Number of ms between calls to check dscp-node status                                                                          |
+| SUBSTRATE_STATUS_TIMEOUT_MS     |    N     |       `2 * 1000`       | Number of ms to wait for response to dscp-node health requests                                                                |
+| IPFS_STATUS_POLL_PERIOD_MS      |    N     |      `10 * 1000`       | Number of ms between calls to check ipfs status                                                                               |
+| IPFS_STATUS_TIMEOUT_MS          |    N     |       `2 * 1000`       | Number of ms to wait for response to ipfs health requests                                                                     |
+| AUTH_TYPE                       |    N     |         `NONE`         | Authentication type for routes on the service. Valid values: [`NONE`, `JWT`, `EXTERNAL`]                                      |
 
 The following environment variables are additionally used when `AUTH_TYPE : 'JWT'`
 
-| variable       | required |                       default                       | description                                                           |
-| :------------- | :------: | :-------------------------------------------------: | :-------------------------------------------------------------------- |
-| AUTH_JWKS_URI  |    N     | `https://inteli.eu.auth0.com/.well-known/jwks.json` | JSON Web Key Set containing public keys used by the Auth0 API         |
-| AUTH_AUDIENCE  |    N     |                    `inteli-dev`                     | Identifier of the Auth0 API                                           |
-| AUTH_ISSUER    |    N     |           `https://inteli.eu.auth0.com/`            | Domain of the Auth0 API `                                             |
-
+| variable      | required |                       default                       | description                                                   |
+| :------------ | :------: | :-------------------------------------------------: | :------------------------------------------------------------ |
+| AUTH_JWKS_URI |    N     | `https://inteli.eu.auth0.com/.well-known/jwks.json` | JSON Web Key Set containing public keys used by the Auth0 API |
+| AUTH_AUDIENCE |    N     |                    `inteli-dev`                     | Identifier of the Auth0 API                                   |
+| AUTH_ISSUER   |    N     |           `https://inteli.eu.auth0.com/`            | Domain of the Auth0 API `                                     |
 
 ## Running the API
 

--- a/app/env.js
+++ b/app/env.js
@@ -19,7 +19,7 @@ const AUTH_ENVS = {
 }
 
 const { AUTH_TYPE } = envalid.cleanEnv(process.env, {
-  AUTH_TYPE: envalid.str({ default: 'NONE', choices: ['NONE', 'JWT'] }),
+  AUTH_TYPE: envalid.str({ default: 'NONE', choices: ['NONE', 'JWT', 'EXTERNAL'] }),
 })
 
 const vars = envalid.cleanEnv(process.env, {

--- a/app/util/auth.js
+++ b/app/util/auth.js
@@ -54,6 +54,7 @@ export const getDefaultSecurity = () => {
     case 'NONE':
       return []
     case 'JWT':
+    case 'EXTERNAL':
       return [{ bearerAuth: [] }]
     default:
       return []

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dscp-api",
-  "version": "4.8.4",
+  "version": "4.8.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dscp-api",
-      "version": "4.8.4",
+      "version": "4.8.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dscp-api",
-  "version": "4.8.4",
+  "version": "4.8.5",
   "description": "DSCP API",
   "type": "module",
   "repository": {


### PR DESCRIPTION
Add an `AUTH_TYPE: EXTERNAL` that keeps no auth at the service level (default behaviour) but displays swagger authentication options so a `Authorization` header can be added easily. Used when `dscp-api` is deployed to authorise at ingress level rather than service level. 

`AUTH_TYPE=EXTERNAL npm run dev`

![image](https://user-images.githubusercontent.com/40722025/224715894-2dad3d5a-77a3-4b46-ad6c-1929676b84e3.png)