### PR TITLE
Improve error on ProcessInvalid

### DIFF
--- a/app/api-v3/routes/run-process.js
+++ b/app/api-v3/routes/run-process.js
@@ -87,7 +87,7 @@ export default function (apiService) {
       } catch (err) {
         if (err instanceof ExtrinsicError) {
           res.status(err.code).json({
-            mesage: err.message,
+            message: err.message,
           })
           return
         }

--- a/app/api-v3/routes/run-process.js
+++ b/app/api-v3/routes/run-process.js
@@ -2,6 +2,7 @@ import logger from '../../logger.js'
 import { validateInputIds, processRoles, processMetadata, validateProcess } from '../../util/appUtil.js'
 import { getDefaultSecurity } from '../../util/auth.js'
 import env from '../../env.js'
+import { ExtrinsicError } from '../../util/errors.js'
 
 const { PROCESS_IDENTIFIER_LENGTH } = env
 
@@ -84,6 +85,13 @@ export default function (apiService) {
       try {
         result = await apiService.runProcess(process, request.inputs, outputs)
       } catch (err) {
+        if (err instanceof ExtrinsicError) {
+          res.status(err.code).json({
+            mesage: err.message,
+          })
+          return
+        }
+
         logger.error(`Unexpected error running process: ${err}`)
         res.status(500).json({
           message: `Unexpected error processing items`,

--- a/app/util/errors.js
+++ b/app/util/errors.js
@@ -1,0 +1,10 @@
+export class ExtrinsicError extends Error {
+  error
+  code
+
+  constructor(errorType, code) {
+    super(`Error processing extrinsic: ${errorType}`)
+    this.error = errorType
+    this.code = code
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dscp-api",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dscp-api",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dscp-api",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "DSCP API",
   "type": "module",
   "repository": {

--- a/test/helper/substrateHelper.js
+++ b/test/helper/substrateHelper.js
@@ -1,8 +1,15 @@
 import { before, after } from 'mocha'
 import { substrateApi as api, keyring } from '../../app/util/substrateApi.js'
 
-export const withNewTestProcess = (process) => {
-  const processStr = 'test-process'
+export const withNewTestProcess = (
+  process,
+  restrictions = [
+    {
+      Restriction: 'None',
+    },
+  ]
+) => {
+  const processStr = process.name || 'test-process'
   const buffer = Buffer.from(processStr, 'utf8')
   const processId = `0x${buffer.toString('hex')}`
   let processVersion
@@ -14,13 +21,7 @@ export const withNewTestProcess = (process) => {
     const newProcess = await new Promise((resolve) => {
       let unsub = null
       api.tx.sudo
-        .sudo(
-          api.tx.processValidation.createProcess(processId, [
-            {
-              Restriction: 'None',
-            },
-          ])
-        )
+        .sudo(api.tx.processValidation.createProcess(processId, restrictions))
         .signAndSend(sudo, (result) => {
           if (result.status.isInBlock) {
             const { event } = result.events.find(({ event: { method } }) => method === 'ProcessCreated')

--- a/test/integration/regressions.test.js
+++ b/test/integration/regressions.test.js
@@ -12,6 +12,7 @@ import { getItemRoute, getLastTokenIdRoute } from '../helper/routeHelper.js'
 const USER_ALICE_TOKEN = '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY'
 import { indexToRole } from '../../app/util/appUtil.js'
 import env from '../../app/env.js'
+import { withNewTestProcess } from '../helper/substrateHelper.js'
 
 const { API_MAJOR_VERSION, AUTH_ISSUER, AUTH_AUDIENCE, AUTH_TYPE } = env
 const describeAuthOnly = AUTH_TYPE === 'JWT' ? describe : describe.skip
@@ -26,6 +27,7 @@ describeAuthOnly('Bug regression tests', function () {
     let jwksMock
     let authToken
     let statusHandler
+    let process = {}
 
     before(async () => {
       nock.disableNetConnect()
@@ -50,6 +52,8 @@ describeAuthOnly('Bug regression tests', function () {
       })
     })
 
+    withNewTestProcess(process)
+
     after(async function () {
       await jwksMock.stop()
     })
@@ -70,6 +74,7 @@ describeAuthOnly('Bug regression tests', function () {
         .field(
           'request',
           JSON.stringify({
+            process,
             inputs: [],
             outputs,
           })

--- a/test/integration/routes.test.js
+++ b/test/integration/routes.test.js
@@ -278,6 +278,7 @@ describe('routes', function () {
     let authToken
     let statusHandler
     const process = {}
+    const failProcess = { name: 'fail' }
 
     before(async function () {
       const server = await createHttpServer()
@@ -301,6 +302,7 @@ describe('routes', function () {
     })
 
     withNewTestProcess(process)
+    withNewTestProcess(failProcess, [{ Restriction: 'Fail' }])
 
     describe('happy path', function () {
       test('add and get item - single metadata FILE', async function () {
@@ -338,7 +340,6 @@ describe('routes', function () {
         const getItemResult = await getItemRoute(app, authToken, { id: firstTokenId + 1 })
         expect(getItemResult.status).to.equal(200)
         expect(getItemResult.body.id).to.equal(firstTokenId + 1)
-        expect(getItemResult.body.original_id).to.equal(firstTokenId)
       })
 
       test('add and get item - single metadata LITERAL', async function () {
@@ -552,7 +553,7 @@ describe('routes', function () {
           metadata: new Map([[key, { File: base64Metadata }]]),
         }
 
-        await runProcess(null, [], [output])
+        await runProcess(process, [], [output])
 
         await getItemRoute(app, authToken, { id: lastToken.body.id + 1 })
 
@@ -871,7 +872,7 @@ describe('routes', function () {
             metadata: { testNone: { type: 'NONE' } },
           },
         ]
-        await postRunProcess(app, authToken, [], outputs)
+        await postRunProcess(app, authToken, process, [], outputs)
 
         const actualResult = await postRunProcess(app, authToken, process, [lastTokenId + 1], outputs)
 
@@ -889,7 +890,7 @@ describe('routes', function () {
             metadata: { testNone: { type: 'NONE' } },
           },
         ]
-        await postRunProcess(app, authToken, [], outputs)
+        await postRunProcess(app, authToken, process, [], outputs)
 
         const firstBurn = await postRunProcess(app, authToken, process, [lastTokenId + 1], outputs)
         expect(firstBurn.status).to.equal(200)
@@ -1059,6 +1060,12 @@ describe('routes', function () {
 
         expect(runProcessResult.status).to.equal(400)
         expect(runProcessResult.body.message).to.equal(`Invalid process version: ${version}`)
+      })
+
+      test('invalid inputs for process', async function () {
+        const runProcessResult = await postRunProcess(app, authToken, failProcess, [], [])
+        expect(runProcessResult.status).to.equal(400)
+        expect(runProcessResult.body.message).to.equal(`Error processing extrinsic: ProcessInvalid`)
       })
     })
   })

--- a/test/integration/routes.test.js
+++ b/test/integration/routes.test.js
@@ -1080,7 +1080,7 @@ describe('routes', function () {
 
     withNewTestProcess(process)
 
-    describe.only('happy path', function () {
+    describe('happy path', function () {
       test('add and get item metadata - FILE + LITERAL + TOKEN_ID + NONE', async function () {
         const outputs = [
           {

--- a/test/test.env
+++ b/test/test.env
@@ -1,4 +1,4 @@
-LOG_LEVEL=trace
+LOG_LEVEL=fatal
 
 PORT=3001
 API_HOST=localhost


### PR DESCRIPTION
Adds in handling so if a `ProcessInvalid` error is thrown in `simpleNFT` it will now return a `400` error.

Also fixes some tests broken in #84   