### PR TITLE
Remove 'Default role must be in roles' check

### DIFF
--- a/app/util/appUtil.js
+++ b/app/util/appUtil.js
@@ -55,11 +55,6 @@ function formatHash(filestoreResponse) {
 }
 
 export const processRoles = async (roles) => {
-  const defaultRole = await indexToRole(0)
-  if (!roles[defaultRole]) {
-    throw new Error(`Roles must include default ${defaultRole} role. Roles: ${JSON.stringify(roles)}`)
-  }
-
   if (await containsInvalidMembershipRoles(roles)) {
     throw new Error(`Request contains roles with account IDs not in the membership list`)
   }
@@ -363,15 +358,12 @@ export const getReadableMetadataKeys = (metadata) => {
 
 export const validateInputIds = async (accountIds) => {
   await api.isReady
-  const userId = keyring.addFromUri(USER_URI).address
 
   return await accountIds.reduce(async (acc, id) => {
     const uptoNow = await acc
     if (!uptoNow || !id || !Number.isInteger(id)) return false
 
-    const { roles, id: echoId, children } = await getItem(id)
-    const defaultRole = await indexToRole(0)
-    if (roles[defaultRole] !== userId) return false
+    const { id: echoId, children } = await getItem(id)
 
     return children === null && echoId === id
   }, Promise.resolve(true))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dscp-api",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dscp-api",
-      "version": "5.0.3",
+      "version": "5.0.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dscp-api",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "description": "DSCP API",
   "type": "module",
   "repository": {

--- a/test/integration/routes.test.js
+++ b/test/integration/routes.test.js
@@ -883,13 +883,11 @@ describe('routes', function () {
         expect(secondBurn.body.message).to.contain(lastTokenId + 1)
       })
 
-      test('add item - no default role', async function () {
-        const outputs = [
-          { roles: { [await indexToRole(1)]: USER_ALICE_TOKEN }, metadata: { testNone: { type: 'NONE' } } },
-        ]
+      test('add item - no roles', async function () {
+        const outputs = [{ metadata: { testNone: { type: 'NONE' } } }]
         const runProcessResult = await postRunProcess(app, authToken, process, [], outputs)
         expect(runProcessResult.status).to.equal(400)
-        expect(runProcessResult.body.message).to.contain('default')
+        expect(runProcessResult.body.message).to.contain('roles')
       })
 
       test('add item - invalid role', async function () {

--- a/test/integration/routes.test.js
+++ b/test/integration/routes.test.js
@@ -863,24 +863,6 @@ describe('routes', function () {
         expect(actualResult.body).to.deep.equal(expectedResult)
       })
 
-      test('failure to destroy token with member not having correct role', async function () {
-        const lastToken = await getLastTokenIdRoute(app, authToken)
-        const lastTokenId = lastToken.body.id
-        const outputs = [
-          {
-            roles: { [await indexToRole(0)]: USER_BOB_TOKEN, [await indexToRole(1)]: USER_ALICE_TOKEN },
-            metadata: { testNone: { type: 'NONE' } },
-          },
-        ]
-        await postRunProcess(app, authToken, process, [], outputs)
-
-        const actualResult = await postRunProcess(app, authToken, process, [lastTokenId + 1], outputs)
-
-        expect(actualResult.status).to.equal(400)
-        expect(actualResult.body).to.have.property('message')
-        expect(actualResult.body.message).to.contain(lastTokenId + 1)
-      })
-
       test('failure to burn a token twice', async function () {
         const lastToken = await getLastTokenIdRoute(app, authToken)
         const lastTokenId = lastToken.body.id
@@ -899,13 +881,6 @@ describe('routes', function () {
         expect(secondBurn.status).to.equal(400)
         expect(secondBurn.body).to.have.property('message')
         expect(secondBurn.body.message).to.contain(lastTokenId + 1)
-      })
-
-      test('add item - no roles', async function () {
-        const outputs = [{ metadata: { testNone: { type: 'NONE' } } }]
-        const runProcessResult = await postRunProcess(app, authToken, process, [], outputs)
-        expect(runProcessResult.status).to.equal(400)
-        expect(runProcessResult.body.message).to.contain('roles')
       })
 
       test('add item - no default role', async function () {


### PR DESCRIPTION
Tokens don’t always need the default role (`owner`) since https://github.com/digicatapult/dscp-node/pull/118 made it so you must provide a process when doing a `run-process`. Specifically it removed these two checks:
```
 ensure!(
      output.roles.contains_key(&T::RoleKey::default()),
      Error::<T>::NoDefaultRole
  );

ensure!(token.roles[&T::RoleKey::default()] == sender, Error::<T>::NotOwned);
```

this removes the same validation from `dscp-api`