### PR TITLE
Chore/update simple nft events

### DIFF
--- a/app/util/appUtil.js
+++ b/app/util/appUtil.js
@@ -255,9 +255,8 @@ export async function runProcess(process, inputs, outputs) {
               reject(ProcessExtrinsicError(errors[0]))
             }
 
-            const tokens = result.events
-              .filter(({ event: { method } }) => method === 'Minted')
-              .map(({ event: { data } }) => data[0].toNumber())
+            const processRanEvent = result.events.find(({ event: { method } }) => method === 'ProcessRan')
+            const tokens = processRanEvent?.event?.data?.outputs?.map((x) => x.toNumber())
 
             unsub()
             resolve(tokens)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,7 +23,7 @@ services:
       - 8081:8080
       - 5002:5001
   dscp-node:
-    image: digicatapult/dscp-node:v5.0.2
+    image: digicatapult/dscp-node:v5.0.3
     command:
       --base-path /data/
       --dev

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dscp-api",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dscp-api",
-      "version": "5.0.4",
+      "version": "5.0.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dscp-api",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "description": "DSCP API",
   "type": "module",
   "repository": {

--- a/test/integration/regressions.test.js
+++ b/test/integration/regressions.test.js
@@ -1,4 +1,4 @@
-import mockJwks from 'mock-jwks'
+import createJWKSMock from 'mock-jwks'
 import { describe, test, before, after } from 'mocha'
 import { expect } from 'chai'
 import nock from 'nock'
@@ -16,10 +16,6 @@ import { withNewTestProcess } from '../helper/substrateHelper.js'
 
 const { API_MAJOR_VERSION, AUTH_ISSUER, AUTH_AUDIENCE, AUTH_TYPE } = env
 const describeAuthOnly = AUTH_TYPE === 'JWT' ? describe : describe.skip
-
-// it's super weird that we have to do this. createJWKSMock is declared as the default
-// export of mock-jwks but module resolution isn't working. Issue in mocha?
-const createJWKSMock = mockJwks.default
 
 describeAuthOnly('Bug regression tests', function () {
   describe('API run-process is broken with file uploads (https://github.com/digicatapult/dscp-api/issues/17)', function () {

--- a/test/integration/routes.test.js
+++ b/test/integration/routes.test.js
@@ -1,4 +1,4 @@
-import mockJwks from 'mock-jwks'
+import createJWKSMock from 'mock-jwks'
 import { describe, test, before, after, afterEach } from 'mocha'
 import { expect } from 'chai'
 import nock from 'nock'
@@ -44,10 +44,6 @@ const {
   IPFS_PORT,
   AUTH_TYPE,
 } = env
-
-// it's super weird that we have to do this. createJWKSMock is declared as the default
-// export of mock-jwks but module resolution isn't working. Issue in mocha?
-const createJWKSMock = mockJwks.default
 
 const describeAuthOnly = AUTH_TYPE === 'JWT' ? describe : describe.skip
 const describeNoAuthOnly = AUTH_TYPE === 'NONE' ? describe : describe.skip


### PR DESCRIPTION
Companion PR to https://github.com/digicatapult/dscp-node/pull/125. Also upgrade `mock-jwks` and thus superceeds #83 
