### PR TITLE
Remove external origin envs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,27 +52,25 @@ npm run test:integration
 
 The following environment variables are used by `dcsp-api` and can be configured. Entries marked as `required` are needed when running `dscp-api` in production mode.
 
-| variable                        | required |        default         | description                                                                                                                   |
-| :------------------------------ | :------: | :--------------------: | :---------------------------------------------------------------------------------------------------------------------------- |
-| PORT                            |    N     |         `3001`         | The port for the API to listen on                                                                                             |
-| EXTERNAL_ORIGIN                 |    N     |                        | The origin from which the OpenAPI service is accessible. If not provided the value will default to `http://localhost:${PORT}` |
-| EXTERNAL_PATH_PREFIX            |    N     |                        | A path prefix from which this service is served                                                                               |
-| API_HOST                        |    Y     |           -            | The hostname of the `dscp-node` the API should connect to                                                                     |
-| API_PORT                        |    N     |         `9944`         | The port of the `dscp-node` the API should connect to                                                                         |
-| LOG_LEVEL                       |    N     |         `info`         | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`]                                          |
-| USER_URI                        |    Y     |           -            | The Substrate `URI` representing the private key to use when making `dscp-node` transactions                                  |
-| IPFS_HOST                       |    Y     |           -            | Hostname of the `IPFS` node to use for metadata storage                                                                       |
-| IPFS_PORT                       |    N     |        `15001`         | Port of the `IPFS` node to use for metadata storage                                                                           |
-| METADATA_KEY_LENGTH             |    N     |          `32`          | Fixed length of metadata keys                                                                                                 |
-| METADATA_VALUE_LITERAL_LENGTH   |    N     |          `32`          | Fixed length of metadata LITERAL values                                                                                       |
-| API_VERSION                     |    N     | `package.json version` | API version                                                                                                                   |
-| API_MAJOR_VERSION               |    N     |          `v3`          | API major version                                                                                                             |
-| FILE_UPLOAD_MAX_SIZE            |    N     |  `200 * 1024 * 1024`   | The Maximum file upload size (bytes)                                                                                          |
-| SUBSTRATE_STATUS_POLL_PERIOD_MS |    N     |      `10 * 1000`       | Number of ms between calls to check dscp-node status                                                                          |
-| SUBSTRATE_STATUS_TIMEOUT_MS     |    N     |       `2 * 1000`       | Number of ms to wait for response to dscp-node health requests                                                                |
-| IPFS_STATUS_POLL_PERIOD_MS      |    N     |      `10 * 1000`       | Number of ms between calls to check ipfs status                                                                               |
-| IPFS_STATUS_TIMEOUT_MS          |    N     |       `2 * 1000`       | Number of ms to wait for response to ipfs health requests                                                                     |
-| AUTH_TYPE                       |    N     |         `NONE`         | Authentication type for routes on the service. Valid values: [`NONE`, `JWT`, `EXTERNAL`]                                      |
+| variable                        | required |        default         | description                                                                                  |
+| :------------------------------ | :------: | :--------------------: | :------------------------------------------------------------------------------------------- |
+| PORT                            |    N     |         `3001`         | The port for the API to listen on                                                            |
+| API_HOST                        |    Y     |           -            | The hostname of the `dscp-node` the API should connect to                                    |
+| API_PORT                        |    N     |         `9944`         | The port of the `dscp-node` the API should connect to                                        |
+| LOG_LEVEL                       |    N     |         `info`         | Logging level. Valid values are [`trace`, `debug`, `info`, `warn`, `error`, `fatal`]         |
+| USER_URI                        |    Y     |           -            | The Substrate `URI` representing the private key to use when making `dscp-node` transactions |
+| IPFS_HOST                       |    Y     |           -            | Hostname of the `IPFS` node to use for metadata storage                                      |
+| IPFS_PORT                       |    N     |        `15001`         | Port of the `IPFS` node to use for metadata storage                                          |
+| METADATA_KEY_LENGTH             |    N     |          `32`          | Fixed length of metadata keys                                                                |
+| METADATA_VALUE_LITERAL_LENGTH   |    N     |          `32`          | Fixed length of metadata LITERAL values                                                      |
+| API_VERSION                     |    N     | `package.json version` | API version                                                                                  |
+| API_MAJOR_VERSION               |    N     |          `v3`          | API major version                                                                            |
+| FILE_UPLOAD_MAX_SIZE            |    N     |  `200 * 1024 * 1024`   | The Maximum file upload size (bytes)                                                         |
+| SUBSTRATE_STATUS_POLL_PERIOD_MS |    N     |      `10 * 1000`       | Number of ms between calls to check dscp-node status                                         |
+| SUBSTRATE_STATUS_TIMEOUT_MS     |    N     |       `2 * 1000`       | Number of ms to wait for response to dscp-node health requests                               |
+| IPFS_STATUS_POLL_PERIOD_MS      |    N     |      `10 * 1000`       | Number of ms between calls to check ipfs status                                              |
+| IPFS_STATUS_TIMEOUT_MS          |    N     |       `2 * 1000`       | Number of ms to wait for response to ipfs health requests                                    |
+| AUTH_TYPE                       |    N     |         `NONE`         | Authentication type for routes on the service. Valid values: [`NONE`, `JWT`, `EXTERNAL`]     |
 
 The following environment variables are additionally used when `AUTH_TYPE : 'JWT'`
 
@@ -153,7 +151,18 @@ The `inputs` field is an array of token `id`s that identifies the tokens to be c
 The `outputs` field is an array of objects that describe tokens to be created by running this process. To destroy tokens without creating any new ones simply pass an empty array. Each output must reference a `roles` object containing a (key, value) pair for each role associated with the new token. The value is the `AccountId` for the role. At minimum, a token requires the default `Owner` role to be set. The following role keys are accepted:
 
 ```json
-["Owner", "Customer", "AdditiveManufacturer", "Laboratory", "Buyer", "Supplier", "Reviewer", "Optimiser", "MemberA", "MemberB"]
+[
+  "Owner",
+  "Customer",
+  "AdditiveManufacturer",
+  "Laboratory",
+  "Buyer",
+  "Supplier",
+  "Reviewer",
+  "Optimiser",
+  "MemberA",
+  "MemberB"
+]
 ```
 
 Each output must also reference a `metadata` object containing a (key, value) pair for each metadata item associated with the new token. The following metadata value types are accepted:

--- a/app/api-v3/api-doc.js
+++ b/app/api-v3/api-doc.js
@@ -1,12 +1,6 @@
 import env from '../env.js'
 
-const { PORT, API_VERSION, API_MAJOR_VERSION, EXTERNAL_ORIGIN, EXTERNAL_PATH_PREFIX } = env
-
-let url = EXTERNAL_ORIGIN || `http://localhost:${PORT}`
-if (EXTERNAL_PATH_PREFIX) {
-  url = `${url}/${EXTERNAL_PATH_PREFIX}`
-}
-url = `${url}/${API_MAJOR_VERSION}`
+const { PORT, API_VERSION, API_MAJOR_VERSION } = env
 
 const apiDoc = {
   openapi: '3.0.3',
@@ -16,7 +10,7 @@ const apiDoc = {
   },
   servers: [
     {
-      url,
+      url: `http://localhost:${PORT}/${API_MAJOR_VERSION}`,
     },
   ],
   components: {

--- a/app/env.js
+++ b/app/env.js
@@ -41,8 +41,6 @@ const vars = envalid.cleanEnv(process.env, {
   SUBSTRATE_STATUS_TIMEOUT_MS: envalid.num({ default: 2 * 1000 }),
   IPFS_STATUS_POLL_PERIOD_MS: envalid.num({ default: 10 * 1000 }),
   IPFS_STATUS_TIMEOUT_MS: envalid.num({ default: 2 * 1000 }),
-  EXTERNAL_ORIGIN: envalid.str({ default: '' }),
-  EXTERNAL_PATH_PREFIX: envalid.str({ default: '' }),
 })
 
 export default {

--- a/app/server.js
+++ b/app/server.js
@@ -22,7 +22,7 @@ import url from 'url'
 const __filename = url.fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 
-const { PORT, API_VERSION, API_MAJOR_VERSION, AUTH_TYPE, EXTERNAL_PATH_PREFIX } = env
+const { PORT, API_VERSION, API_MAJOR_VERSION, AUTH_TYPE } = env
 
 export async function createHttpServer() {
   const requestLogger = pinoHttp({ logger })
@@ -116,11 +116,7 @@ export async function createHttpServer() {
     },
   }
 
-  app.use(
-    EXTERNAL_PATH_PREFIX ? `/${EXTERNAL_PATH_PREFIX}/${API_MAJOR_VERSION}/swagger` : `/${API_MAJOR_VERSION}/swagger`,
-    swaggerUi.serve,
-    swaggerUi.setup(null, options)
-  )
+  app.use(`/${API_MAJOR_VERSION}/swagger`, swaggerUi.serve, swaggerUi.setup(null, options))
 
   // Sorry - app.use checks arity
   // eslint-disable-next-line no-unused-vars

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dscp-api",
-  "version": "5.0.7",
+  "version": "5.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dscp-api",
-      "version": "5.0.7",
+      "version": "5.0.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^10.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dscp-api",
-  "version": "5.0.7",
+  "version": "5.0.8",
   "description": "NodeJS API service for DSCP",
   "type": "module",
   "repository": {


### PR DESCRIPTION
Remove `EXTERNAL_ORIGIN` and `EXTERNAL_PATH_PREFIX` as they never worked how we wanted them to serve multiple APIs specs on the same prefix (instead we merge specs with https://github.com/digicatapult/wasp-open-api)